### PR TITLE
Return your own object so $customer = $customer->save() is supported

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Storable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Storable.php
@@ -13,10 +13,10 @@ trait Storable {
     {
         if ($this->exists())
         {
-            $this->update();
+            return $this->update();
         } else
         {
-            $this->insert();
+            return $this->insert();
         }
     }
 
@@ -27,7 +27,7 @@ trait Storable {
     {
         $result = $this->connection()->post($this->url, $this->jsonWithNamespace());
 
-        $this->selfFromResponse($result);
+        return $this->selfFromResponse($result);
     }
 
     /**
@@ -37,7 +37,7 @@ trait Storable {
     {
         $result = $this->connection()->patch($this->url . '/' . urlencode($this->id), $this->jsonWithNamespace());
 
-        $this->selfFromResponse($result);
+        return $this->selfFromResponse($result);
     }
 
 }

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -253,6 +253,8 @@ abstract class Model
             $instaniatedEntity = new $entityName($this->connection);
             $this->$key = $instaniatedEntity->collectionFromResult($response[$key]);
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When you use $customer = $customer->save(), $customer will be null. With these changes also in that case the customer var will be filled with the object.
