### PR TITLE
Added 'period' as fillable attribute for SalesInvoiceDetail

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceDetail.php
@@ -18,6 +18,7 @@ class SalesInvoiceDetail extends Model
         'ledger_account_id',
         'amount',
         'description',
+        'period',
         'price',
         'row_order',
         'total_price_excl_tax_with_discount',


### PR DESCRIPTION
According to the [API docs](http://developer.moneybird.com/api/sales_invoices/#post_sales_invoices) it's possible to assign a period to invoice items. I tested it and it works exactly like the API docs say: it's accepted (and saved) when you create a new invoice, but unfortunately it's not returned when you request (GET) an invoice.
