### PR TITLE
Add details to recurring sales invoices

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
@@ -53,4 +53,18 @@ class RecurringSalesInvoice extends Model {
      * @var string
      */
     protected $namespace = 'recurring_sales_invoice';
+
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'details' => [
+            'entity' => 'SalesInvoiceDetail',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+        'payments' => [
+            'entity' => 'SalesInvoicePayment',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
 }


### PR DESCRIPTION
This makes it possible to use `details` on recurring sales invoices. There's probably a neater way to implement this by extending `SalesInvoice` or something, but I needed this quickly :)
