### PR TITLE
$attributeEntity causes invoiceline fail

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -221,7 +221,7 @@ abstract class Model
 
                 $result[$attributeNameToUse] = [];
                 foreach ($attributeValue as $attributeEntity) {
-                    $result[$attributeNameToUse][] = $attributeEntity->attributes;
+                    $result[$attributeNameToUse][] = $attributeEntity;
 
                     if ($multipleNestedEntities[$attributeName]['type'] === self::NESTING_TYPE_NESTED_OBJECTS) {
                         $result[$attributeNameToUse] = (object)$result[$attributeNameToUse];


### PR DESCRIPTION
When using $attributeEntity->attributes, the creation of invoice details fails. When removing ->attributes it works because $attributeEntity doesn't have an attributes key.
