### PR TITLE
Do not include namespace when none set

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -195,7 +195,11 @@ abstract class Model
      */
     public function jsonWithNamespace()
     {
-        return json_encode([$this->namespace => $this->getArrayWithNestedObjects()]);
+        if ($this->namespace !== '') {
+            return json_encode([$this->namespace => $this->getArrayWithNestedObjects()]);
+        } else {
+            return $this->json();
+        }
     }
 
     private function getArrayWithNestedObjects($useAttributesAppend = true)


### PR DESCRIPTION
Due to this a webhook can not be pushed. Because payload includes an empty namespace, even though none is set.
