### PR TITLE
Moneybird expects numbered objects instead of arrays in json body. 

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -187,7 +187,7 @@ abstract class Model
     {
         $array = $this->getArrayWithNestedObjects();
 
-        return json_encode($array);
+        return json_encode($array, JSON_FORCE_OBJECT);
     }
 
     /**
@@ -195,7 +195,7 @@ abstract class Model
      */
     public function jsonWithNamespace()
     {
-        return json_encode([$this->namespace => $this->getArrayWithNestedObjects()]);
+        return json_encode([$this->namespace => $this->getArrayWithNestedObjects()], JSON_FORCE_OBJECT);
     }
 
     private function getArrayWithNestedObjects($useAttributesAppend = true)


### PR DESCRIPTION
Moneybird API expects numbered objects instead of arrays in json body of post requests.
(See [example request in documentation](http://developer.moneybird.com/api/sales_invoices/#post_sales_invoices_example0))

This pull request adds JSON_FORCE_OJBECT when encoding to json
