### PR TITLE
Adds feature to set custom fields on salesInvoices

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Generic/CustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Generic/CustomField.php
@@ -1,0 +1,18 @@
+<?php namespace Picqer\Financials\Moneybird\Entities\Generic;
+
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class CustomField
+ * @package Picqer\Financials\Moneybird\Entities\Generic
+ */
+abstract class CustomField extends Model
+{
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'value'
+    ];
+}

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -24,6 +24,7 @@ class SalesInvoice extends Model {
         'contact_id',
         'contact',
         'invoice_id',
+        'invoice_sequence_id',
         'workflow_id',
         'document_style_id',
         'identity_id',
@@ -81,6 +82,10 @@ class SalesInvoice extends Model {
         ],
         'payments' => [
             'entity' => 'SalesInvoicePayment',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+        'custom_fields' => [
+            'entity' => 'SalesInvoiceCustomField',
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
         ],
     ];

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceCustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceCustomField.php
@@ -1,0 +1,11 @@
+<?php namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\CustomField;
+
+/**
+ * Class SalesInvoiceCustomField
+ * @package Picqer\Financials\Moneybird\Entities
+ */
+class SalesInvoiceCustomField extends CustomField
+{
+}

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -21,6 +21,7 @@ use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoice;
 use Picqer\Financials\Moneybird\Entities\SalesInvoice;
 use Picqer\Financials\Moneybird\Entities\SalesInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\SalesInvoicePayment;
+use Picqer\Financials\Moneybird\Entities\SalesInvoiceCustomField;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
 use Picqer\Financials\Moneybird\Entities\TypelessDocument;
 use Picqer\Financials\Moneybird\Entities\Webhook;
@@ -236,6 +237,15 @@ class Moneybird
     public function salesInvoicePayment($attributes = [])
     {
         return new SalesInvoicePayment($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return SalesInvoiceCustomField
+     */
+    public function salesInvoiceCustomField($attributes = [])
+    {
+        return new SalesInvoiceCustomField($this->connection, $attributes);
     }
 
     /**


### PR DESCRIPTION
Adds entities and methods to set custom fields on salesInvoices and set the invoice_sequence_id via the api 

Depends on #36 because moneybird API will only properly parse posted body if encode as a json object instead of an array.
