### PR TITLE
Add desired count to recurring sales invoices

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
@@ -42,6 +42,8 @@ class RecurringSalesInvoice extends Model {
         'details',
         'notes',
         'attachments',
+        'has_desired_count',
+        'desired_count',
     ];
 
     /**


### PR DESCRIPTION
This allows recurring sales invoices to be sent a finite number of times, instead of for eternity
