### PR TITLE
Add download() method to SalesInvoice

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/PrivateDownloadable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/PrivateDownloadable.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Actions;
+
+use GuzzleHttp\Psr7\Request;
+
+/**
+ * Class PrivateDownloadable
+ * 
+ * This download as PDF method is a private API method. It is currently
+ * officially unsupported, but serves a purpose until Moneybird updates
+ * their API to provide PDF files.
+ * 
+ * @package Picqer\Financials\Moneybird\Actions
+ */
+trait PrivateDownloadable
+{
+    
+    /**
+     * Download invoice as PDF
+     *
+     * @return string PDF file data
+     */
+    public function download()
+    {
+        $connection = $this->connection;
+        $client = $connection->connect();
+        
+        $headers = [
+            'Accept' => 'application/pdf',
+            'Content-Type' => 'application/pdf',
+            'Authorization' => 'Bearer ' . $connection->getAccessToken(),
+        ];
+
+        $endpoint = 'https://moneybird.com/' . $connection->getAdministrationId() . '/sales_invoices/' . $this->id . '.pdf';
+        $body = '';
+            
+        $request = new Request('GET', $endpoint, $headers, $body);
+        $response = $client->send($request);
+
+        return $response->getBody()->getContents();
+    }
+
+}

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -3,6 +3,7 @@
 use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
+use Picqer\Financials\Moneybird\Actions\PrivateDownloadable;
 use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
@@ -15,7 +16,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class SalesInvoice extends Model {
 
-    use FindAll, FindOne, Storable, Removable, Filterable, Synchronizable;
+    use FindAll, FindOne, Storable, Removable, Filterable, PrivateDownloadable, Synchronizable;
 
     /**
      * @var array


### PR DESCRIPTION
This adds a `PrivateDownloadable` action to the `SalesInvoice` model. Named this `PrivateDownloadable` because it is not an officially supported API method. But it works fine and serves it purpose until Moneybird decides to implement this officially. Because it is officially unsupported, I decided not to refactor the `Connection::createRequest()`.
