### PR TITLE
Make estimates downloadable

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/PrivateDownloadable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/PrivateDownloadable.php
@@ -32,7 +32,7 @@ trait PrivateDownloadable
             'Authorization' => 'Bearer ' . $connection->getAccessToken(),
         ];
 
-        $endpoint = 'https://moneybird.com/' . $connection->getAdministrationId() . '/sales_invoices/' . $this->id . '.pdf';
+        $endpoint = 'https://moneybird.com/' . $connection->getAdministrationId() . '/' . $this->endpoint . '/' . $this->id . '.pdf';
         $body = '';
             
         $request = new Request('GET', $endpoint, $headers, $body);

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -6,6 +6,7 @@ use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Actions\Filterable;
+use Picqer\Financials\Moneybird\Actions\PrivateDownloadable;
 use Picqer\Financials\Moneybird\Model;
 
 /**
@@ -20,7 +21,7 @@ use Picqer\Financials\Moneybird\Model;
 class Estimate extends Model
 {
 
-    use FindAll, FindOne, Storable, Removable, Synchronizable, Filterable;
+    use FindAll, FindOne, Storable, Removable, Synchronizable, Filterable, PrivateDownloadable;
 
     /**
      * @var array

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -30,7 +30,7 @@ class Estimate extends Model
         'id',
         'contact_id',
         'contact',
-        'esimate_id',
+        'estimate_id',
         'workflow_id',
         'document_style_id',
         'identity_id',


### PR DESCRIPTION
This PR adds the possibilty to download an estimate with the `PrivateDownloadable` trait currently only used for SalesInvoices.

Also fixes a typo in 'estimate_id', now able to fetch this property correctly.
