### PR TITLE
Add frequency & frequency_type to Product entity

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Product.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Product.php
@@ -21,6 +21,8 @@ class Product extends Model {
         'id',
         'description',
         'price',
+        'frequency',
+        'frequency_type',
         'tax_rate_id',
         'ledger_account_id',
         'created_at',


### PR DESCRIPTION
These 2 fields were added in the API today (still undocumented at the moment, but expect that this will be fixed soon)

> Bedankt voor je bericht. We hebben zojuist de attributen "frequency" en "frequency_type" toegevoegd aan producten in de API. Als je nu een product ophaalt zul je die beide zien.