### PR TITLE
Add SalesInvoice fields to Estimate

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -73,5 +73,23 @@ class Estimate extends Model
      * @var string
      */
     protected $namespace = 'estimate';
+    
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'custom_fields' => [
+            'entity' => 'SalesInvoiceCustomField',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+        'details' => [
+            'entity' => 'SalesInvoiceDetail',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+        'notes' => [
+            'entity' => 'Note',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
 
 }


### PR DESCRIPTION
When creating an estimate it is useful to be able to add SalesInvoiceCustomField, SalesInvoiceDetail and Notes to the estimate.