### PR TITLE
Add support for pagination

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -22,4 +22,19 @@ trait Filterable
         return $this->collectionFromResult($result);
     }
 
+    /**
+     * @return mixed
+     */
+    public function filterAll(array $filters)
+    {
+        $filterList = [];
+        foreach ($filters as $key => $value) {
+            $filterList[] = $key .':' . $value;
+        }
+
+        $result = $this->connection()->get($this->getEndpoint(), ['filter' => implode(',', $filterList)], true);
+
+        return $this->collectionFromResult($result);
+    }
+
 }

--- a/src/Picqer/Financials/Moneybird/Actions/FindAll.php
+++ b/src/Picqer/Financials/Moneybird/Actions/FindAll.php
@@ -17,4 +17,14 @@ trait FindAll
         return $this->collectionFromResult($result);
     }
 
+    /**
+     * @return mixed
+     */
+    public function getAll()
+    {
+        $result = $this->connection()->get($this->getEndpoint(), [], true);
+
+        return $this->collectionFromResult($result);
+    }
+
 }

--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -81,11 +81,6 @@ class Connection
     private $scopes = [];
 
     /**
-     * @var bool
-     */
-    private $followPagination = true;
-
-    /**
      * @return Client
      */
     private function client()
@@ -172,10 +167,11 @@ class Connection
     /**
      * @param $url
      * @param array $params
+     * @param bool $fetchAll
      * @return mixed
      * @throws ApiException
      */
-    public function get($url, array $params = [])
+    public function get($url, array $params = [], $fetchAll = false)
     {
         try {
             $request = $this->createRequest('GET', $this->formatUrl($url, 'get'), null, $params);
@@ -183,9 +179,9 @@ class Connection
 
             $json = $this->parseResponse($response);
 
-            if ($this->followPagination) {
+            if ($fetchAll === true) {
                 if (($nextParams = $this->getNextParams($response->getHeaderLine('Link')))) {
-                    $json = array_merge($json, $this->get($url, $nextParams));
+                    $json = array_merge($json, $this->get($url, $nextParams, $fetchAll));
                 }
             }
 
@@ -484,14 +480,6 @@ class Connection
     public function setScopes($scopes)
     {
         $this->scopes = $scopes;
-    }
-
-    /**
-     * @param bool $followPagination
-     */
-    public function setFollowPagination($followPagination)
-    {
-        $this->followPagination = $followPagination;
     }
 
 }

--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -81,6 +81,11 @@ class Connection
     private $scopes = [];
 
     /**
+     * @var bool
+     */
+    private $followPagination = true;
+
+    /**
      * @return Client
      */
     private function client()
@@ -178,8 +183,10 @@ class Connection
 
             $json = $this->parseResponse($response);
 
-            if (($nextParams = $this->getNextParams($response->getHeaderLine('Link')))) {
-                $json = array_merge($json, $this->get($url, $nextParams));
+            if ($this->followPagination) {
+                if (($nextParams = $this->getNextParams($response->getHeaderLine('Link')))) {
+                    $json = array_merge($json, $this->get($url, $nextParams));
+                }
             }
 
             return $json;
@@ -477,6 +484,14 @@ class Connection
     public function setScopes($scopes)
     {
         $this->scopes = $scopes;
+    }
+
+    /**
+     * @param bool $followPagination
+     */
+    public function setFollowPagination($followPagination)
+    {
+        $this->followPagination = $followPagination;
     }
 
 }


### PR DESCRIPTION
This pull requests adds minimal support for pagination. Ideally would be to pass a parameter to the FindAll::get method to enable/disable pagination and return either just the single batch results or a batch object containting the results and a method to retrieve next batch. This way users are more flexible when it comes to API request limiting but that change required too much refactoring.

Tips and all are welcome