### PR TITLE
Update SalesInvoice.php

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -114,6 +114,8 @@ class SalesInvoice extends Model {
                 'delivery_method' => $deliveryMethod
             ]
         ]));
+	    
+	return $this;
     }
 
     /**


### PR DESCRIPTION
When issuing a `sendInvoice` method on a SalesInvoice Entity you weren't able to get the fresh data (like invoice_id, invoice_date and state) without creating a seperate call to the API. By returning `$this` you are now able to chain the command like:

```php
// Get a draft
$invoice = $moneybird->salesInvoice()->find('MONEYBIRD_INVOICE_ID');
$invoice->invoice_id; // null

// Send an invoice 
$sent = $invoice->sendInvoice()->find('MONEYBIRD_INVOICE_ID');
$sent->invoice_id; // 2017-0014
```

Very useful in situations where sending is done seperate from creating the drafts and the updated properties need to be saved to the database.