### PR TITLE
Register payment is deprecated and has been replaced by create a payment

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -150,7 +150,7 @@ class SalesInvoice extends Model {
             throw new ApiException('Required [price] is missing');
         }
 
-        $this->connection()->patch($this->endpoint . '/' . $this->id . '/register_payment',
+        $this->connection()->post($this->endpoint . '/' . $this->id . '/payments',
             $salesInvoicePayment->jsonWithNamespace()
         );
 	    


### PR DESCRIPTION
https://developer.moneybird.com/api/sales_invoices/#patch_sales_invoices_id_register_payment