### PR TITLE
#121: Remove unreachable code in ConnectionTest.

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -151,10 +151,6 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
                         return $response->withHeader($header, $value);
                     }
                 );
-
-                $request = $request->withHeader($header, $value);
-
-                return $handler($request, $options);
             };
         };
     }


### PR DESCRIPTION
I am not sure if this is the correct solution. Maybe the code I remove should stay, and the statment before should be modified?

Fixes #121, I suppose.