### PR TITLE
add receipt detail class

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Receipt.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Receipt.php
@@ -53,4 +53,14 @@ class Receipt extends Model {
      * @var string
      */
     protected $namespace = 'receipt';
+
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'details' => [
+            'entity' => 'ReceiptDetail',
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
@@ -3,7 +3,7 @@
 use Picqer\Financials\Moneybird\Model;
 
 /**
- * Class PurchaseInvoiceDetail
+ * Class ReceiptDetail
  * @package Picqer\Financials\Moneybird\Entities
  */
 class ReceiptDetail extends Model

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
@@ -1,0 +1,25 @@
+<?php namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class PurchaseInvoiceDetail
+ * @package Picqer\Financials\Moneybird\Entities
+ */
+class ReceiptDetail extends Model
+{
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'description',
+        'period',
+        'price',
+        'amount',
+        'tax_rate_id',
+        'ledger_account_id',
+        'row_order',
+        '_destroy',
+    ];
+}

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -20,6 +20,7 @@ use Picqer\Financials\Moneybird\Entities\PurchaseInvoice;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoicePayment;
 use Picqer\Financials\Moneybird\Entities\Receipt;
+use Picqer\Financials\Moneybird\Entities\ReceiptDetail;
 use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoice;
 use Picqer\Financials\Moneybird\Entities\Note;
 use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoiceDetail;
@@ -251,6 +252,15 @@ class Moneybird
     public function receipt($attributes = [])
     {
         return new Receipt($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\ReceiptDetail
+     */
+    public function receiptDetail($attributes = [])
+    {
+        return new ReceiptDetail($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -94,6 +94,11 @@ class EntityTest extends \PHPUnit_Framework_TestCase
         $this->performEntityTest(\Picqer\Financials\Moneybird\Entities\Receipt::class);
     }
 
+    public function testReceiptDetailEntity()
+    {
+        $this->performEntityTest(\Picqer\Financials\Moneybird\Entities\ReceiptDetail::class);
+    }
+
     public function testRecurringSalesInvoiceEntity()
     {
         $this->performEntityTest(\Picqer\Financials\Moneybird\Entities\RecurringSalesInvoice::class);


### PR DESCRIPTION
When using this library to create a receipt I received a `422 details.description can not be empty`.
Turns out that there was no detail object like there is for salesInvoice & purchaseInvoice.

This change add an ReceiptDetail class, and maps it to Receipt so that the following doesn't result in an error

```php
$detail = [
    'id'                    => 1,
    'description'    => 'this is the first receipt',
];
$attributes = [
    'contact_id'            => ${contact_id},
    'reference'             => ${reference},
    'date'                  => ${date},
    'currency'              => 'EUR',
    'prices_are_incl_tax'   => true,
    'origin'                => 'api',
    'details'               => [Moneybird::receiptDetail($detail)],
];

$new_receipt = Moneybird::receipt($attributes)->insert();
```