### PR TITLE
Add a payment to an existing receipt

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Receipt.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Receipt.php
@@ -4,6 +4,7 @@ use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
+use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
 /**
@@ -63,4 +64,28 @@ class Receipt extends Model {
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
         ],
     ];
+
+    /**
+     * Register a payment for the current purchase invoice
+     *
+     * @param ReceiptPayment $receiptPayment (payment_date and price are required)
+     * @return $this
+     * @throws ApiException
+     */
+    public function registerPayment(ReceiptPayment $receiptPayment)
+    {
+        if  (! isset($receiptPayment->payment_date)) {
+            throw new ApiException('Required [payment_date] is missing');
+        }
+
+        if  (! isset($receiptPayment->price)) {
+            throw new ApiException('Required [price] is missing');
+        }
+
+        $this->connection()->post($this->endpoint . '/' . $this->id . '/payments',
+            $receiptPayment->jsonWithNamespace()
+        );
+
+        return $this;
+    }
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptPayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptPayment.php
@@ -1,0 +1,34 @@
+<?php namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class InvoicePayment
+ * @package Picqer\Financials\Moneybird\Entities
+ */
+class ReceiptPayment extends Model {
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'invoice_type',
+        'invoice_id',
+        'financial_account_id',
+        'user_id',
+        'payment_transaction_id',
+        'price',
+        'price_base',
+        'payment_date',
+        'credit_invoice_id',
+        'financial_mutation_id',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $namespace = 'payment';
+}

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -12,6 +12,7 @@ use Picqer\Financials\Moneybird\Entities\FinancialStatement;
 use Picqer\Financials\Moneybird\Entities\GeneralDocument;
 use Picqer\Financials\Moneybird\Entities\GeneralJournalDocument;
 use Picqer\Financials\Moneybird\Entities\GeneralJournalDocumentEntry;
+use Picqer\Financials\Moneybird\Entities\ReceiptPayment;
 use Picqer\Financials\Moneybird\Entities\Identity;
 use Picqer\Financials\Moneybird\Entities\ImportMapping;
 use Picqer\Financials\Moneybird\Entities\LedgerAccount;
@@ -264,6 +265,16 @@ class Moneybird
     public function receiptDetail($attributes = [])
     {
         return new ReceiptDetail($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     *
+     * @return ReceiptPayment
+     */
+    public function receiptPayment($attributes = [])
+    {
+        return new ReceiptPayment($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -18,6 +18,8 @@ use Picqer\Financials\Moneybird\Entities\Product;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoice;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\Receipt;
+use Picqer\Financials\Moneybird\Entities\ReceiptDetail;
+use Picqer\Financials\Moneybird\Entities\ReceiptPayment;
 use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoice;
 use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoiceCustomField;
 use Picqer\Financials\Moneybird\Entities\RecurringSalesInvoiceDetail;
@@ -127,7 +129,12 @@ class EntityTest extends \PHPUnit_Framework_TestCase
 
     public function testReceiptDetailEntity()
     {
-        $this->performEntityTest(\Picqer\Financials\Moneybird\Entities\ReceiptDetail::class);
+        $this->performEntityTest(ReceiptDetail::class);
+    }
+
+    public function testReceiptPaymentEntity()
+    {
+        $this->performEntityTest(ReceiptPayment::class);
     }
 
     public function testRecurringSalesInvoiceEntity()


### PR DESCRIPTION
When creating receipts, it wasn't possible to register a payment to a specific receipt.

This change adds the following
1. ReceiptPayment Entity (including EntityTest)
2. a `registerPayment` method, with which a payment can be registered to a receipt
3. access the `receiptPayment` from the main Moneybird class