### PR TITLE
Add account_servicer_transaction_id to FinancialMutation

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
@@ -38,6 +38,7 @@ class FinancialMutation extends Model {
         'processed_at',
         'payments',
         'ledger_account_bookings',
+        'account_servicer_transaction_id',
     ];
 
     /**


### PR DESCRIPTION
Moneybird includes the `account_servicer_transaction_id` in the resultset when fetching a `FinancialMutation`, but the model in the library does not (yet) include the field so it isn't available easily.

This PR adds the `account_servicer_transaction_id` to the `FinancialMutation` model.