### PR TITLE
Added refresh token

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -60,6 +60,11 @@ class Connection
     /**
      * @var
      */
+    private $refreshToken;
+
+    /**
+     * @var
+     */
     private $redirectUrl;
 
     /**
@@ -253,7 +258,7 @@ class Connection
     /**
      * @return string
      */
-    private function getAuthUrl()
+    public function getAuthUrl()
     {
         return $this->authUrl . '?' . http_build_query(array(
             'client_id' => $this->clientId,
@@ -367,6 +372,14 @@ class Connection
     }
 
     /**
+     * @return mixed
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
      * @throws ApiException
      */
     private function acquireAccessToken()
@@ -389,6 +402,7 @@ class Connection
 
             if (json_last_error() === JSON_ERROR_NONE) {
                 $this->accessToken = array_key_exists('access_token', $body) ? $body['access_token'] : null;
+                $this->refreshToken = array_key_exists('refresh_token', $body) ? $body['refresh_token'] : null;
             } else {
                 throw new ApiException('Could not acquire tokens, json decode failed. Got response: ' . $response->getBody()->getContents());
             }


### PR DESCRIPTION
As stated in the [documentation](https://developer.moneybird.com/authentication/) by @Moneybird, the refresh token should be persisted in all cases. This is not possible with the current implementation.

> The response contains an Access token which you can use to connect with the API. The Refresh token can be used to retreive a new access token in case the access token can expire. In that case, an `expires_in` is given. Both the access token and the refresh token should be persisted to be used for future requests. 

It's a bit unclear to me whether the access token can actually expire, since I was not able to retrieve an `expires_in`. In any case we should be able to persist the refresh just in case.

Another small change here is making the `getAuthUrl` public since we then could use framework methods for redirecting, e.g. in Laravel: `return redirect($connection->getAuthUrl());`.