### PR TITLE
Make the delete body nullable

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -273,7 +273,7 @@ class Connection
      * @return mixed
      * @throws ApiException
      */
-    public function delete($url, $body)
+    public function delete($url, $body = null)
     {
         try {
             $request = $this->createRequest('DELETE', $this->formatUrl($url, 'delete'), $body);


### PR DESCRIPTION
Resolves #159 

Right now when you try to delete a sales_invoice it says $body parameter is missing. Making it optional resolves it.