### PR TITLE
Added pause and resume workflow for invoices.

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -235,7 +235,7 @@ class SalesInvoice extends Model {
     /**
      * Pauses the sales invoice. The automatic workflow steps will not be executed while the sales invoice is paused.
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
@@ -257,7 +257,7 @@ class SalesInvoice extends Model {
     /**
      * Resumes the sales invoice. The automatic workflow steps will execute again after resuming.
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -231,4 +231,48 @@ class SalesInvoice extends Model {
 
         return $this;
     }
+
+    /**
+     * Pauses the sales invoice. The automatic workflow steps will not be executed while the sales invoice is paused.
+     *
+     * @return boolean
+     *
+     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
+     */
+    public function pauseWorkflow()
+    {
+        try {
+            $this->connection()->post($this->endpoint . '/' . $this->id . '/pause', json_encode([]));
+        } catch (ApiException $exception) {
+            if (strpos($exception->getMessage(), "The sales_invoice is already paused") !== false) {
+                return true; // Everything is fine since the sales invoice was already paused we don't need an error.
+            }
+
+            throw $exception;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resumes the sales invoice. The automatic workflow steps will execute again after resuming.
+     *
+     * @return boolean
+     *
+     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
+     */
+    public function resumeWorkflow()
+    {
+        try {
+            $this->connection()->post($this->endpoint . '/' . $this->id . '/resume', json_encode([]));
+        } catch (ApiException $exception) {
+            if (strpos($exception->getMessage(), "The sales_invoice isn't paused") !== false) {
+                return true; // Everything is fine since the sales invoice wasn't paused we don't need an error.
+            }
+
+            throw $exception;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
This change enables the use of pausing and resuming workflows for sales invoices.

Docs from moneybird can be found here : https://developer.moneybird.com/api/sales_invoices/#post_sales_invoices_id_pause
https://developer.moneybird.com/api/sales_invoices/#post_sales_invoices_id_resume