### PR TITLE
Add first_due_interval to SalesInvoice Entity

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -38,6 +38,7 @@ class SalesInvoice extends Model {
         'state',
         'invoice_date',
         'due_date',
+        'first_due_interval',
         'payment_conditions',
         'reference',
         'language',


### PR DESCRIPTION
Moneybird does not accept due date when creating a new invoice, but uses an integer named 'first_due_interval' to determine the due_date. (number of days to be added to the invoice_date)

Added this to $fillable to allow sending it to the API