### PR TITLE
Added parameter argument for retrieving lists

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/FindAll.php
+++ b/src/Picqer/Financials/Moneybird/Actions/FindAll.php
@@ -9,18 +9,22 @@ trait FindAll
     use BaseTrait;
 
     /**
+     * @param array $params
+     * 
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    public function get()
+    public function get($params = [])
     {
-        $result = $this->connection()->get($this->getEndpoint());
+        $result = $this->connection()->get($this->getEndpoint(), $params);
 
         return $this->collectionFromResult($result);
     }
 
     /**
+     * @param array $params
+     * 
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException


### PR DESCRIPTION
Allows to fetch a specific page with a specific filter option. For example if you want to implement pagination yourself. `getAll`, makes multiple calls sometimes you want to avoid this. To avoid the rate limit for example. 

```
        $moneybirdInvoices = $this->moneybird()->salesInvoice()->get([
            "period" => "201001..201912",
            "per_page" => 100,
            "page" => 3
        ]);
```