### PR TITLE
Allow entities to define JSON options

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Webhook.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Webhook.php
@@ -13,6 +13,8 @@ class Webhook extends Model {
 
     use FindAll, Storable, Removable;
 
+    const JSON_OPTIONS = 0;
+
     /**
      * @var array
      */

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -9,6 +9,7 @@ abstract class Model
 
     const NESTING_TYPE_ARRAY_OF_OBJECTS = 0;
     const NESTING_TYPE_NESTED_OBJECTS = 1;
+    const JSON_OPTIONS = JSON_FORCE_OBJECT;
 
     /**
      * @var Connection
@@ -190,7 +191,7 @@ abstract class Model
     {
         $array = $this->getArrayWithNestedObjects();
 
-        return json_encode($array, JSON_FORCE_OBJECT);
+        return json_encode($array, static::JSON_OPTIONS);
     }
 
     /**
@@ -199,7 +200,7 @@ abstract class Model
     public function jsonWithNamespace()
     {
         if ($this->namespace !== '') {
-            return json_encode([$this->namespace => $this->getArrayWithNestedObjects()], JSON_FORCE_OBJECT);
+            return json_encode([$this->namespace => $this->getArrayWithNestedObjects()], static::JSON_OPTIONS);
         } else {
             return $this->json();
         }


### PR DESCRIPTION
By empowering entities to change the behavior of JSON encoding, by
populating a JSON_OPTIONS class constant, an inconsistency between
expected representation by the Moneybird API can be solved through
configuration.

This solves #163 