### PR TITLE
Add register payment for credit invoices

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -205,6 +205,22 @@ class SalesInvoice extends Model {
 
         return $this->makeFromResponse($response);
     }
+    
+    /**
+     * Register a payment for a credit invoice.
+     *
+     * @return \Picqer\Financials\Moneybird\Entities\SalesInvoice
+     *
+     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
+     */
+    public function registerPaymentForCreditInvoice()
+    {
+        $response = $this->connection()->patch($this->getEndpoint() . '/' . $this->id . '/register_payment_creditinvoice',
+            json_encode([])	// No body needed for this call. The patch method however needs one.
+        );
+
+        return $this->makeFromResponse($response);
+    }
 
     /**
      * Add Attachment to this invoice


### PR DESCRIPTION
Implements [this](https://developer.moneybird.com/api/sales_invoices/#patch_sales_invoices_id_register_payment_creditinvoice) API call into this library, it allows us to set a credit invoice and its referencing sales invoice to paid.