### PR TITLE
Add ability to delete sales payment

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -173,6 +173,24 @@ class SalesInvoice extends Model {
 
         return $this;
     }
+    
+    /**
+     * Delete a payment for the current invoice
+     *
+     * @param SalesInvoicePayment $salesInvoicePayment (id is required)
+     * @return $this
+     * @throws ApiException
+     */
+    public function deletePayment(SalesInvoicePayment $salesInvoicePayment)
+    {
+        if  (! isset($salesInvoicePayment->id)) {
+            throw new ApiException('Required [id] is missing');
+        }
+
+        $this->connection()->delete($this->endpoint . '/' . $this->id . '/payments/' . $salesInvoicePayment->id);
+
+        return $this;
+    }
 
     /**
      * Add a note to the current invoice


### PR DESCRIPTION
Implements [this](https://developer.moneybird.com/api/sales_invoices/#delete_sales_invoices_sales_invoice_id_payments_id) API call into this library, it allows us to remove a payment for a sales invoice.