### PR TITLE
Add a dirty attributes check to the model (issue #179)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": "~6.0",
+    "ext-json": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Picqer/Financials/Moneybird/Actions/Storable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Storable.php
@@ -18,7 +18,8 @@ trait Storable {
         if ($this->exists())
         {
             return $this->update();
-        } else
+        }
+        else
         {
             return $this->insert();
         }
@@ -33,6 +34,10 @@ trait Storable {
     {
         $result = $this->connection()->post($this->getEndpoint(), $this->jsonWithNamespace());
 
+        if (method_exists($this, 'clearDirty')) {
+            $this->clearDirty();
+        }
+
         return $this->selfFromResponse($result);
     }
 
@@ -44,7 +49,12 @@ trait Storable {
     public function update()
     {
         $result = $this->connection()->patch($this->getEndpoint() . '/' . urlencode($this->id), $this->jsonWithNamespace());
+
         if ($result === 200) {
+            if (method_exists($this, 'clearDirty')) {
+                $this->clearDirty();
+            }
+
             return true;
         }
 

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -107,7 +107,7 @@ abstract class Model
      * @param array $attributes
      * @param bool $first_initialize
      */
-    protected function fill(array $attributes, bool $first_initialize = false)
+    protected function fill(array $attributes, bool $first_initialize)
     {
         if($first_initialize) {
             $this->enableFirstInitialize();

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -107,7 +107,7 @@ abstract class Model
      * @param array $attributes
      * @param boolean $first_initialize
      */
-    protected function fill(array $attributes, boolean $first_initialize)
+    protected function fill(array $attributes, $first_initialize)
     {
         if($first_initialize) {
             $this->enableFirstInitialize();

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -105,9 +105,9 @@ abstract class Model
      * Fill the entity from an array
      *
      * @param array $attributes
-     * @param bool $first_initialize
+     * @param boolean $first_initialize
      */
-    protected function fill(array $attributes, bool $first_initialize)
+    protected function fill(array $attributes, boolean $first_initialize)
     {
         if($first_initialize) {
             $this->enableFirstInitialize();
@@ -181,7 +181,7 @@ abstract class Model
                 $from = $this->attributes[$key];
             }
 
-            
+
             $this->attribute_changes[$key] = [
                 'from' => $from,
                 'to' => $value

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -175,8 +175,15 @@ abstract class Model
     protected function setAttribute($key, $value)
     {
         if(!isset($this->attribute_changes[$key])) {
+            $from = null;
+
+            if(isset($this->attributes[$key])) {
+                $from = $this->attributes[$key];
+            }
+
+            
             $this->attribute_changes[$key] = [
-                'from' => $this->attributes[$key],
+                'from' => $from,
                 'to' => $value
             ];
         } else {

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -21,6 +21,16 @@ abstract class Model
     protected $attributes = [ ];
 
     /**
+     * @var array The model's changed attributes
+     */
+    protected $attribute_changes = [ ];
+
+    /**
+     * @var bool Register the intilized state of this model for dirty attributes registration
+     */
+    protected $initializing = false;
+
+    /**
      * @var array The model's fillable attributes
      */
     protected $fillable = [ ];
@@ -65,7 +75,7 @@ abstract class Model
     public function __construct(Connection $connection, array $attributes = [ ])
     {
         $this->connection = $connection;
-        $this->fill($attributes);
+        $this->fill($attributes, false);
     }
 
 
@@ -95,14 +105,39 @@ abstract class Model
      * Fill the entity from an array
      *
      * @param array $attributes
+     * @param bool $first_initialize
      */
-    protected function fill(array $attributes)
+    protected function fill(array $attributes, bool $first_initialize = false)
     {
+        if($first_initialize) {
+            $this->enableFirstInitialize();
+        }
+
         foreach ($this->fillableFromArray($attributes) as $key => $value) {
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             }
         }
+
+        if($first_initialize) {
+            $this->disableFirstInitialize();
+        }
+    }
+
+
+    /**
+     * Register the current model as initializing
+     */
+    protected function enableFirstInitialize() {
+        $this->initializing = true;
+    }
+
+
+    /**
+     * Register the current model as initialized
+     */
+    protected function disableFirstInitialize() {
+        $this->initializing = false;
     }
 
 
@@ -139,7 +174,59 @@ abstract class Model
      */
     protected function setAttribute($key, $value)
     {
+        if(!isset($this->attribute_changes[$key])) {
+            $this->attribute_changes[$key] = [
+                'from' => $this->attributes[$key],
+                'to' => $value
+            ];
+        } else {
+            $this->attribute_changes[$key]['to'] = $value;
+        }
+
         $this->attributes[$key] = $value;
+    }
+
+
+    /**
+     * All keys that are changed in this model
+     *
+     * @return array
+     */
+    public function getDirty() {
+        return array_keys($this->attribute_changes);
+    }
+
+
+    /**
+     * All changed keys with it values
+     *
+     * @return array
+     */
+    public function getDirtyValues() {
+        return $this->attribute_changes;
+    }
+
+
+    /**
+     * Check if the attribute is changed since the last save/update/create action
+     *
+     * @param $attributeName
+     * @return bool
+     */
+    public function isAttributeDirty($attributeName) {
+        if(in_array($attributeName, $this->attribute_changes)) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Clear the changed/dirty attribute in this model
+     */
+    public function clearDirty() {
+        $this->attribute_changes = [];
     }
 
 
@@ -199,7 +286,9 @@ abstract class Model
     public function jsonWithNamespace()
     {
         if ($this->namespace !== '') {
-            return json_encode([$this->namespace => $this->getArrayWithNestedObjects()], JSON_FORCE_OBJECT);
+            return json_encode([
+                $this->namespace => $this->getArrayWithNestedObjects()
+            ], JSON_FORCE_OBJECT);
         } else {
             return $this->json();
         }
@@ -217,7 +306,10 @@ abstract class Model
 
         foreach ($this->attributes as $attributeName => $attributeValue) {
             if (! is_object($attributeValue)) {
-                $result[$attributeName] = $attributeValue;
+                //check if result is changed
+                if($this->isAttributeDirty($attributeName)) {
+                    $result[$attributeName] = $attributeValue;
+                }
             }
 
             if (array_key_exists($attributeName, $this->getSingleNestedEntities())) {
@@ -277,7 +369,7 @@ abstract class Model
      */
     public function selfFromResponse(array $response)
     {
-        $this->fill($response);
+        $this->fill($response, true);
 
         foreach ($this->getSingleNestedEntities() as $key => $value)
         {
@@ -345,10 +437,12 @@ abstract class Model
     public function __debugInfo()
     {
         $result = [];
+
         foreach ($this->fillable as $attribute)
         {
             $result[$attribute] = $this->$attribute;
         }
+
         return $result;
     }
 

--- a/tests/PicqerTest/Financials/Moneybird/ModelTest.php
+++ b/tests/PicqerTest/Financials/Moneybird/ModelTest.php
@@ -96,4 +96,32 @@ class ModelTest extends TestCase {
         }
     }
 
+    public function testRegisterAttributesAsDirty()
+    {
+        $invoice = new SalesInvoice($this->connection->reveal());
+
+        $id = 1;
+        $invoice_date = '2019-01-01';
+        $dummyResponse = [
+            'id' => $id,
+            'invoice_date' => $invoice_date,
+            'ignoredAttribute' => 'ignoredValue'
+        ];
+
+        $invoice = $invoice->makeFromResponse($dummyResponse);
+
+        //check if the correct dirty values are set
+        $this->assertEquals('id', $invoice->getDirty()[0]);
+        $this->assertEquals('invoice_date', $invoice->getDirty()[1]);
+        $this->assertEquals(2, count($invoice->getDirty()));
+
+        //check if the getDirtyValues from is null (new object)
+        $this->assertEquals(null, $invoice->getDirtyValues()['invoice_date']['from']);
+        $this->assertEquals(null, $invoice->getDirtyValues()['id']['from']);
+
+        //check if the getDirtyValues from is filled with the new value (new object)
+        $this->assertEquals($id, $invoice->getDirtyValues()['id']['to']);
+        $this->assertEquals($invoice_date, $invoice->getDirtyValues()['invoice_date']['to']);
+    }
+
 }


### PR DESCRIPTION
There was a attribute (for me) given by the moneybird api response that contains a invoice_file_hash, this should not be passed to the save/update api when it's not updated:

> The invoice file hash is being created by us, so you cannot and should not update this.

For more information, take a look at: #179