### PR TITLE
Fix: Saving custom fields causes: Cannot use object of type stdClass as array

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -234,10 +234,10 @@ abstract class Model
                 $result[$attributeNameToUse] = [];
                 foreach ($attributeValue as $attributeEntity) {
                     $result[$attributeNameToUse][] = $attributeEntity->attributes;
+                }
 
-                    if ($multipleNestedEntities[$attributeName]['type'] === self::NESTING_TYPE_NESTED_OBJECTS) {
-                        $result[$attributeNameToUse] = (object)$result[$attributeNameToUse];
-                    }
+                if ($multipleNestedEntities[$attributeName]['type'] === self::NESTING_TYPE_NESTED_OBJECTS) {
+                    $result[$attributeNameToUse] = (object)$result[$attributeNameToUse];
                 }
 
                 if (

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -227,7 +227,7 @@ abstract class Model
                 }
 
                 if ($multipleNestedEntities[$attributeName]['type'] === self::NESTING_TYPE_NESTED_OBJECTS) {
-                    $result[$attributeNameToUse] = (object)$result[$attributeNameToUse];
+                    $result[$attributeNameToUse] = (object) $result[$attributeNameToUse];
                 }
 
                 if (


### PR DESCRIPTION
## Full error
Cannot use object of type stdClass as array at vendor/picqer/moneybird-php-client/src/Picqer/Financials/Moneybird/Model.php:236

## Solves
- [Issue 162](https://github.com/picqer/moneybird-php-client/issues/162)
- [Issue 143](https://github.com/picqer/moneybird-php-client/issues/143)