### PR TITLE
SalesInvoice and Estimate entities make use of received data

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -117,9 +117,13 @@ class Estimate extends Model
             throw new InvalidArgumentException("Expected string or options instance. Received: '$options'");
         }
 
-        $this->connection->patch($this->endpoint . '/' . $this->id . '/send_estimate', json_encode([
+        $response = $this->connection->patch($this->endpoint . '/' . $this->id . '/send_estimate', json_encode([
             'estimate_sending' => $options->jsonSerialize(),
         ]));
+
+        if (is_array($response)) {
+            $this->selfFromResponse($response);
+        }
 
         return $this;
     }

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -128,9 +128,13 @@ class SalesInvoice extends Model
             throw new InvalidArgumentException("Expected string or options instance. Received: '$options'");
         }
 
-        $this->connection->patch($this->endpoint . '/' . $this->id . '/send_invoice', json_encode([
+        $response = $this->connection->patch($this->endpoint . '/' . $this->id . '/send_invoice', json_encode([
             'sales_invoice_sending' => $options->jsonSerialize(),
         ]));
+
+        if (is_array($response)) {
+            $this->selfFromResponse($response);
+        }
 
         return $this;
     }


### PR DESCRIPTION
I asked the MoneyBird devs if the SalesInvoice sendInvoice method could directly return the corresponding invoice number. They happily did this :clap:. This PR makes use of that new piece of API.

The changelog reads:

> Instead of responding with only `200` we now return the resulting object data on sending sales invoices or estimates through the `/sales_invoices/:id/send_invoice` and `/estimates/:id/send_estimate` endpoints.
> -- https://developer.moneybird.com/changelog/