### PR TITLE
We have added a transaction_identifier field to payments

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Generic/InvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Generic/InvoicePayment.php
@@ -24,6 +24,7 @@ abstract class InvoicePayment extends Model
         'payment_date',
         'credit_invoice_id',
         'financial_mutation_id',
+        'transaction_identifier',
         'created_at',
         'updated_at',
     ];


### PR DESCRIPTION
See changelog 2019-11-19: https://developer.moneybird.com/changelog/

We have added a transaction_identifier field to payments. This allows you to store the identifier of a Payment Service Provider transaction. If you use Mollie for payments, the identifier will be used to automatically link the payments to the pay out of Mollie on your bank account.