### PR TITLE
Add support for external sales invoices and adding an attachment to a receipt

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Attachment.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Attachment.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Actions;
+
+use Picqer\Financials\Moneybird\Exceptions\ApiException;
+
+/**
+ * @property string $id
+ */
+trait Attachment
+{
+    use BaseTrait;
+
+    protected $attachmentPath = 'attachments';
+
+    /**
+     * Add an attachment to this invoice.
+     *
+     * You can use fopen('/path/to/file', 'r') in $resource.
+     *
+     * @param string $filename The filename of the attachment
+     * @param resource $contents A StreamInterface/resource/string, @see http://docs.guzzlephp.org/en/stable/request-options.html?highlight=multipart#multipart
+     *
+     * @return void
+     *
+     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
+     */
+    public function addAttachment($filename, $contents)
+    {
+        if (!isset($this->id)) {
+            throw new ApiException("This method can only be used on existing records.");
+        }
+
+        $this->connection()->upload($this->getEndpoint() . '/' . urlencode($this->id) . '/' . $this->attachmentPath, [
+            'multipart' => [
+                [
+                    'name' => 'file',
+                    'contents' => $contents,
+                    'filename' => $filename,
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Actions\Downloadable;
+use Picqer\Financials\Moneybird\Actions\Filterable;
+use Picqer\Financials\Moneybird\Actions\FindAll;
+use Picqer\Financials\Moneybird\Actions\FindOne;
+use Picqer\Financials\Moneybird\Actions\Removable;
+use Picqer\Financials\Moneybird\Actions\Storable;
+use Picqer\Financials\Moneybird\Actions\Synchronizable;
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class ExternalSalesInvoice.
+ *
+ * @property string $id
+ * @property Contact $contact
+ */
+class ExternalSalesInvoice extends Model
+{
+    use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable;
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'contact_id',
+        'reference',
+        'date',
+        'due_date',
+        'entry_number',
+        'state',
+        'currency',
+        'prices_are_incl_tax',
+        'source',
+        'source_url',
+        'origin',
+        'paid_at',
+        'total_paid',
+        'total_unpaid',
+        'total_price_excl_tax',
+        'total_price_excl_tax_base',
+        'total_price_incl_tax',
+        'total_price_incl_tax_base',
+        'created_at',
+        'updated_at',
+        'details',
+        'payments',
+        'notes',
+        'attachments',
+        'version',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $endpoint = 'external_sales_invoices';
+
+    /**
+     * @var string
+     */
+    protected $namespace = 'external_sales_invoice';
+
+    /**
+     * @var array
+     */
+    protected $singleNestedEntities = [
+        'contact' => Contact::class,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'details' => [
+            'entity' => ExternalSalesInvoiceDetail::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+        'payments' => [
+            'entity' => ExternalSalesInvoicePayment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
+}

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -2,6 +2,7 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+use Picqer\Financials\Moneybird\Actions\Attachment;
 use Picqer\Financials\Moneybird\Actions\Downloadable;
 use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
@@ -9,6 +10,7 @@ use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
+use Picqer\Financials\Moneybird\Connection;
 use Picqer\Financials\Moneybird\Model;
 
 /**
@@ -19,7 +21,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class ExternalSalesInvoice extends Model
 {
-    use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable;
+    use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable, Attachment;
 
     /**
      * @var array
@@ -83,4 +85,11 @@ class ExternalSalesInvoice extends Model
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
         ],
     ];
+
+    public function __construct(Connection $connection, array $attributes = [])
+    {
+        parent::__construct($connection, $attributes);
+
+        $this->attachmentPath = 'attachment';
+    }
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceDetail.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\InvoiceDetail;
+
+/**
+ * Class ExternalSalesInvoiceDetail.
+ */
+class ExternalSalesInvoiceDetail extends InvoiceDetail
+{
+}

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoicePayment.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\InvoicePayment;
+
+/**
+ * Class ExternalSalesInvoicePayment.
+ */
+class ExternalSalesInvoicePayment extends InvoicePayment
+{
+}

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
@@ -2,7 +2,7 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
-use Picqer\Financials\Moneybird\Model;
+use Picqer\Financials\Moneybird\Actions\Attachment;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Storable;
@@ -10,13 +10,14 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
+use Picqer\Financials\Moneybird\Model;
 
 /**
  * Class PurchaseInvoice.
  */
 class PurchaseInvoice extends Model
 {
-    use FindAll, FindOne, Storable, Removable, Filterable, Synchronizable;
+    use FindAll, FindOne, Storable, Removable, Filterable, Synchronizable, Attachment;
 
     /**
      * @var array

--- a/src/Picqer/Financials/Moneybird/Entities/Receipt.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Receipt.php
@@ -2,19 +2,20 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
-use Picqer\Financials\Moneybird\Model;
+use Picqer\Financials\Moneybird\Actions\Attachment;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
+use Picqer\Financials\Moneybird\Model;
 
 /**
  * Class Receipt.
  */
 class Receipt extends Model
 {
-    use FindAll, FindOne, Storable, Removable;
+    use FindAll, FindOne, Storable, Removable, Attachment;
 
     /**
      * @var array

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -3,6 +3,7 @@
 namespace Picqer\Financials\Moneybird\Entities;
 
 use InvalidArgumentException;
+use Picqer\Financials\Moneybird\Actions\Attachment;
 use Picqer\Financials\Moneybird\Actions\Downloadable;
 use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
@@ -22,7 +23,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class SalesInvoice extends Model
 {
-    use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable;
+    use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable, Attachment;
 
     /**
      * @var array
@@ -260,33 +261,6 @@ class SalesInvoice extends Model
         );
 
         return $this->makeFromResponse($response);
-    }
-
-    /**
-     * Add Attachment to this invoice.
-     *
-     * You can use fopen('/path/to/file', 'r') in $resource.
-     *
-     * @param string $filename The filename of the attachment
-     * @param resource $contents A StreamInterface/resource/string, @see http://docs.guzzlephp.org/en/stable/request-options.html?highlight=multipart#multipart
-     *
-     * @return \Picqer\Financials\Moneybird\Entities\SalesInvoice
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
-    public function addAttachment($filename, $contents)
-    {
-        $this->connection()->upload($this->endpoint . '/' . $this->id . '/attachments', [
-            'multipart' => [
-                [
-                    'name' => 'file',
-                    'contents' => $contents,
-                    'filename' => $filename,
-                ],
-            ],
-        ]);
-
-        return $this;
     }
 
     /**

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -2,6 +2,9 @@
 
 namespace Picqer\Financials\Moneybird;
 
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoice;
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoiceDetail;
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoicePayment;
 use Picqer\Financials\Moneybird\Entities\Note;
 use Picqer\Financials\Moneybird\Entities\Contact;
 use Picqer\Financials\Moneybird\Entities\Product;
@@ -122,6 +125,33 @@ class Moneybird
     public function estimate($attributes = [])
     {
         return new Estimate($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\ExternalSalesInvoice
+     */
+    public function externalSalesInvoice($attributes = [])
+    {
+        return new ExternalSalesInvoice($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\ExternalSalesInvoiceDetail
+     */
+    public function externalSalesInvoiceDetail($attributes = [])
+    {
+        return new ExternalSalesInvoiceDetail($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\ExternalSalesInvoicePayment
+     */
+    public function externalSalesInvoicePayment($attributes = [])
+    {
+        return new ExternalSalesInvoicePayment($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -8,6 +8,9 @@ use Picqer\Financials\Moneybird\Entities\Receipt;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
 use Picqer\Financials\Moneybird\Entities\Webhook;
 use Picqer\Financials\Moneybird\Entities\Estimate;
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoice;
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoiceDetail;
+use Picqer\Financials\Moneybird\Entities\ExternalSalesInvoicePayment;
 use Picqer\Financials\Moneybird\Entities\Identity;
 use Picqer\Financials\Moneybird\Entities\Workflow;
 use Picqer\Financials\Moneybird\Entities\CustomField;
@@ -71,6 +74,21 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     public function testEstimateEntity()
     {
         $this->performEntityTest(Estimate::class);
+    }
+
+    public function testExternalSalesInvoice()
+    {
+        $this->performEntityTest(ExternalSalesInvoice::class);
+    }
+
+    public function testExternalSalesInvoiceDetail()
+    {
+        $this->performEntityTest(ExternalSalesInvoiceDetail::class);
+    }
+
+    public function testExternalSalesInvoicePayment()
+    {
+        $this->performEntityTest(ExternalSalesInvoicePayment::class);
     }
 
     public function testFinancialAccountEntity()


### PR DESCRIPTION
See the commits below.

- External sales invoices
- Deduplicated the adding an attachment code to a trait.
- Add an attachment to a receipt.