### PR TITLE
Throw created exception for download and upload

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -312,7 +312,7 @@ class Connection
 
             return $this->client()->send($request, $options);
         } catch (Exception $e) {
-            $this->parseExceptionForErrorMessages($e);
+            throw $this->parseExceptionForErrorMessages($e);
         }
     }
 
@@ -331,7 +331,7 @@ class Connection
 
             return $this->parseResponse($response);
         } catch (Exception $e) {
-            $this->parseExceptionForErrorMessages($e);
+            throw $this->parseExceptionForErrorMessages($e);
         }
     }
 


### PR DESCRIPTION
The throw clauses seem to be missing, thus those function can now return a null-value. And that is why `download` method on the `Downloadable` trait can also return a null-value.

This PR addresses that problem.