### PR TITLE
Add pager to invoice export

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -11,17 +11,28 @@ trait Filterable
 
     /**
      * @param array $filters
+     * @param array $pager_params
      * @return mixed
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    public function filter(array $filters)
+    public function filter(array $filters, $pager_params = false)
     {
         $filterList = [];
         foreach ($filters as $key => $value) {
-            $filterList[] = $key . ':' . $value;
+            $filterList[] = $key .':' . $value;
         }
 
-        $result = $this->connection()->get($this->getEndpoint(), ['filter' => implode(',', $filterList)]);
+        $params['filter'] = implode(',', $filterList);
+        if(isset($pager_params)){
+            if(isset($pager_params['page'])){
+                $params['page'] = $pager_params['page'];
+            }
+            if(isset($pager_params['per_page'])){
+                $params['per_page'] = $pager_params['per_page'];
+            }
+        }
+
+        $result = $this->connection()->get($this->getEndpoint(), $params);
 
         return $this->collectionFromResult($result);
     }


### PR DESCRIPTION
When there are more invoices than 50 you can set a second param to filter method the invoices number to fetch and the page number.