### PR TITLE
Add time_entries as default scope

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -344,7 +344,7 @@ class Connection
             'client_id' => $this->clientId,
             'redirect_uri' => $this->redirectUrl,
             'response_type' => 'code',
-            'scope' => $this->scopes ? implode(' ', $this->scopes) : 'sales_invoices documents estimates bank settings',
+            'scope' => $this->scopes ? implode(' ', $this->scopes) : 'sales_invoices documents estimates bank time_entries settings',
         ]);
     }
 


### PR DESCRIPTION
New scope per 2020-06-03 - "We’ve added an extra scope time_entries, the time_entries API isn’t available yet. Read more about scopes in the authentication documentation."