### PR TITLE
Add support for time entries

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Actions\FindAll;
+use Picqer\Financials\Moneybird\Actions\FindOne;
+use Picqer\Financials\Moneybird\Actions\Removable;
+use Picqer\Financials\Moneybird\Actions\Storable;
+use Picqer\Financials\Moneybird\Model;
+
+class TimeEntry extends Model
+{
+    use FindAll, FindOne, Storable, Removable;
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'started_at',
+        'ended_at',
+        'paused_duration',
+        'contact_id',
+        'project_id',
+        'detail_id',
+        'description',
+        'billable',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $endpoint = 'time_entries';
+}

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -37,6 +37,7 @@ use Picqer\Financials\Moneybird\Entities\SalesInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\SalesInvoicePayment;
 use Picqer\Financials\Moneybird\Entities\SalesInvoiceReminder;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
+use Picqer\Financials\Moneybird\Entities\TimeEntry;
 use Picqer\Financials\Moneybird\Entities\TypelessDocument;
 use Picqer\Financials\Moneybird\Entities\Webhook;
 use Picqer\Financials\Moneybird\Entities\Workflow;
@@ -386,6 +387,15 @@ class Moneybird
     public function taxRate($attributes = [])
     {
         return new TaxRate($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\TimeEntry
+     */
+    public function timeEntry($attributes = [])
+    {
+        return new TimeEntry($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -33,6 +33,7 @@ use Picqer\Financials\Moneybird\Entities\SalesInvoicePayment;
 use Picqer\Financials\Moneybird\Entities\SalesInvoiceReminder;
 use Picqer\Financials\Moneybird\Entities\SalesInvoiceTaxTotal;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
+use Picqer\Financials\Moneybird\Entities\TimeEntry;
 use Picqer\Financials\Moneybird\Entities\TypelessDocument;
 use Picqer\Financials\Moneybird\Entities\Webhook;
 use Picqer\Financials\Moneybird\Entities\Workflow;
@@ -209,6 +210,11 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     public function testTaxRateEntity()
     {
         $this->performEntityTest(TaxRate::class);
+    }
+
+    public function testTimeEntryEntity()
+    {
+        $this->performEntityTest(TimeEntry::class);
     }
 
     public function testTypelessDocumentEntity()


### PR DESCRIPTION
This pull request implements support for time entries, which are now possible in Moneybird.

The example.php can be used for a quick functional test by replacing the `SalesInvoice` code with this:

```php
try {
    $timeEntries = $moneybird->timeEntry()->get();

    foreach ($timeEntries as $entry) {
        var_dump($entry);
    }
} catch (\Exception $e) {
    echo get_class($e) . ' : ' . $e->getMessage();
}

```