### PR TITLE
Implement User entity and fix some TimeEntry bugs

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -31,4 +31,9 @@ class TimeEntry extends Model
      * @var string
      */
     protected $endpoint = 'time_entries';
+
+    /**
+     * @var string
+     */
+    protected $namespace = 'time_entry';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -16,6 +16,7 @@ class TimeEntry extends Model
      * @var array
      */
     protected $fillable = [
+        'id',
         'user_id',
         'started_at',
         'ended_at',

--- a/src/Picqer/Financials/Moneybird/Entities/User.php
+++ b/src/Picqer/Financials/Moneybird/Entities/User.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Actions\FindAll;
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class User.
+ */
+class User extends Model
+{
+    use FindAll;
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'name',
+        'created_at',
+        'updated_at',
+        'email',
+        'email_validated',
+        'language',
+        'time_zone',
+        'permissions',
+        'sales_invoices',
+        'documents',
+        'estimates',
+        'bank',
+        'settings',
+        'ownership',
+        'time_entries',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $endpoint = 'users';
+}

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -39,6 +39,7 @@ use Picqer\Financials\Moneybird\Entities\SalesInvoiceReminder;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
 use Picqer\Financials\Moneybird\Entities\TimeEntry;
 use Picqer\Financials\Moneybird\Entities\TypelessDocument;
+use Picqer\Financials\Moneybird\Entities\User;
 use Picqer\Financials\Moneybird\Entities\Webhook;
 use Picqer\Financials\Moneybird\Entities\Workflow;
 
@@ -405,6 +406,15 @@ class Moneybird
     public function typelessDocument($attributes = [])
     {
         return new TypelessDocument($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\User
+     */
+    public function user($attributes = [])
+    {
+        return new User($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -35,6 +35,7 @@ use Picqer\Financials\Moneybird\Entities\SalesInvoiceTaxTotal;
 use Picqer\Financials\Moneybird\Entities\TaxRate;
 use Picqer\Financials\Moneybird\Entities\TimeEntry;
 use Picqer\Financials\Moneybird\Entities\TypelessDocument;
+use Picqer\Financials\Moneybird\Entities\User;
 use Picqer\Financials\Moneybird\Entities\Webhook;
 use Picqer\Financials\Moneybird\Entities\Workflow;
 use Picqer\Financials\Moneybird\Moneybird;
@@ -220,6 +221,11 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     public function testTypelessDocumentEntity()
     {
         $this->performEntityTest(TypelessDocument::class);
+    }
+
+    public function testUserEntity()
+    {
+        $this->performEntityTest(User::class);
     }
 
     public function testWebhookEntity()


### PR DESCRIPTION
## This PR implements the following:

### Support for the `User` entity. 
Adding new TimeEntries, for example, is impossible without knowing the User ID to which the entry should be linked, so right now, the TImeEntries are not really adding any value without it.

### Improved TimeEntry handling
- Added the `id` property to the object
- Added the `$namespace` variable, so that TimeEntry creation will work.

## Why?
I'm working on a small hobby project that depends on Moneybird time-entries and stumbled upon these issues while implementing it.

## What does this fix?
This makes the current `TimeEntries` feature actually _work_. As it is right now, it cannot be properly used.