### PR TITLE
Bugfix: invalid fillable entries

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/User.php
+++ b/src/Picqer/Financials/Moneybird/Entities/User.php
@@ -25,13 +25,6 @@ class User extends Model
         'language',
         'time_zone',
         'permissions',
-        'sales_invoices',
-        'documents',
-        'estimates',
-        'bank',
-        'settings',
-        'ownership',
-        'time_entries',
     ];
 
     /**


### PR DESCRIPTION
This commit fixes a minor bug where the possible permission entries were accidentally added as fillable properties to the user object.

This should resolve https://github.com/picqer/moneybird-php-client/pull/216#pullrequestreview-521909608.