### PR TITLE
Require psr/http-client as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
   "require": {
     "php": ">=5.6.0",
     "guzzlehttp/guzzle": "^6.3.1|^7.0",
+    "psr/http-client": "^1.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Since this package relies on classes from the psr/http-client package, said package needs to be made into a dependency of this package as well. This in order to prevent the guzzlehttp/guzzle package one day dropping that dependency (theoretical) and breaking this package.

I've found this issue while working on my Mozart package and in more detail have written up the scenario, including relevant links to your codebase, where this is actually a problem already: https://github.com/coenjacobs/mozart/issues/80 This will be fixed in Mozart one day, but one might argue that this is actually a problem in this `moneybird-php-client` library as well.