### PR TITLE
feat: add support for attachments in TypelessDocument

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
@@ -2,6 +2,7 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+use Picqer\Financials\Moneybird\Actions\Attachment;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Removable;
@@ -13,7 +14,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class TypelessDocument extends Model
 {
-    use FindAll, FindOne, Storable, Removable;
+    use Attachment, FindAll, FindOne, Storable, Removable;
 
     /**
      * @var array


### PR DESCRIPTION
Just like `PurchaseInvoice`, a `TypelessDocument` supports attachments. This PR adds attachment support to `TypelessDocument`s.

https://developer.moneybird.com/api/documents_typeless_documents/#post_documents_typeless_documents_id_attachments