### PR TITLE
Add `manual_payment_action` to `InvoicePayment`

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Generic/InvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Generic/InvoicePayment.php
@@ -25,6 +25,7 @@ abstract class InvoicePayment extends Model
         'credit_invoice_id',
         'financial_mutation_id',
         'transaction_identifier',
+        'manual_payment_action',
         'created_at',
         'updated_at',
     ];


### PR DESCRIPTION
According to the docs: https://developer.moneybird.com/api/sales_invoices/#post_sales_invoices_sales_invoice_id_payments

payment[manual_payment_action]: Can be`private_payment`,`payment_without_proof`,`cash_payment`,`rounding_error`,`bank_transfer`,`balance_settlement` or`invoices_settlement`.