### PR TITLE
Expose payment_url on SalesInvoices

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -73,6 +73,7 @@ class SalesInvoice extends Model
         'marked_dubious_on',
         'marked_uncollectible_on',
         'url',
+        'payment_url',
         'custom_fields',
         'notes',
         'attachments',


### PR DESCRIPTION
The SalesInvoice object exposes a nullable `payment_url` property. This PR adds that.

You can see this in the sample response on the https://developer.moneybird.com/api/sales_invoices/#get_sales_invoices_id_example0 page.