### PR TITLE
Fix PHP 8: Required parameter $endpoint follows optional parameter $method

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -158,7 +158,7 @@ class Connection
      * @return \GuzzleHttp\Psr7\Request
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    private function createRequest($method = 'GET', $endpoint, $body = null, array $params = [], array $headers = [])
+    private function createRequest($method = 'GET', $endpoint = '', $body = null, array $params = [], array $headers = [])
     {
         // Add default json headers to the request
         $headers = array_merge($headers, [
@@ -197,7 +197,7 @@ class Connection
      * @return \GuzzleHttp\Psr7\Request
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    private function createRequestNoJson($method = 'GET', $endpoint, $body = null, array $params = [], array $headers = [])
+    private function createRequestNoJson($method = 'GET', $endpoint = '', $body = null, array $params = [], array $headers = [])
     {
         // If access token is not set or token has expired, acquire new token
         if (empty($this->accessToken)) {


### PR DESCRIPTION
PHP 8 throws the exception `Required parameter $endpoint follows optional parameter $method` as mentioned in #223

This can be fixed by either making `endpoint` optional or `method` required. I've opted for the first, as that in theory should be the non-breaking change.. (Even though technically method and endpoint were already both required)
