### PR TITLE
Add Project entity, add sub-entities to TimeEntry

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Project.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Project.php
@@ -21,7 +21,7 @@ class Project extends Model
     protected $fillable = [
         'id',
         'name',
-        'state'
+        'state',
     ];
 
     /**

--- a/src/Picqer/Financials/Moneybird/Entities/Project.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Project.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Actions\FindAll;
+use Picqer\Financials\Moneybird\Actions\FindOne;
+use Picqer\Financials\Moneybird\Actions\Removable;
+use Picqer\Financials\Moneybird\Actions\Storable;
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class Project.
+ */
+class Project extends Model
+{
+    use FindAll, FindOne, Storable, Removable;
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'name',
+        'state'
+    ];
+
+    /**
+     * @var string
+     */
+    protected $endpoint = 'projects';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -47,6 +47,6 @@ class TimeEntry extends Model
     protected $singleNestedEntities = [
         'user' => User::class,
         'project' => Project::class,
-        'detail' => SalesInvoiceDetail::class
+        'detail' => SalesInvoiceDetail::class,
     ];
 }

--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -18,12 +18,15 @@ class TimeEntry extends Model
     protected $fillable = [
         'id',
         'user_id',
+        'user',
         'started_at',
         'ended_at',
         'paused_duration',
         'contact_id',
         'project_id',
+        'project',
         'detail_id',
+        'detail',
         'description',
         'billable',
     ];
@@ -37,4 +40,13 @@ class TimeEntry extends Model
      * @var string
      */
     protected $namespace = 'time_entry';
+
+    /**
+     * @var array
+     */
+    protected $singleNestedEntities = [
+        'user' => User::class,
+        'project' => Project::class,
+        'detail' => SalesInvoiceDetail::class
+    ];
 }

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -22,6 +22,7 @@ use Picqer\Financials\Moneybird\Entities\ImportMapping;
 use Picqer\Financials\Moneybird\Entities\LedgerAccount;
 use Picqer\Financials\Moneybird\Entities\Note;
 use Picqer\Financials\Moneybird\Entities\Product;
+use Picqer\Financials\Moneybird\Entities\Project;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoice;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoicePayment;
@@ -252,6 +253,15 @@ class Moneybird
     public function product($attributes = [])
     {
         return new Product($this->connection, $attributes);
+    }
+
+    /**
+     * @param array $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\Project
+     */
+    public function project($attributes = [])
+    {
+        return new Project($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -18,6 +18,7 @@ use Picqer\Financials\Moneybird\Entities\ImportMapping;
 use Picqer\Financials\Moneybird\Entities\LedgerAccount;
 use Picqer\Financials\Moneybird\Entities\Note;
 use Picqer\Financials\Moneybird\Entities\Product;
+use Picqer\Financials\Moneybird\Entities\Project;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoice;
 use Picqer\Financials\Moneybird\Entities\PurchaseInvoiceDetail;
 use Picqer\Financials\Moneybird\Entities\Receipt;
@@ -131,6 +132,11 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     public function testProductEntity()
     {
         $this->performEntityTest(Product::class);
+    }
+
+    public function testProjectEntity()
+    {
+        $this->performEntityTest(Project::class);
     }
 
     public function testPurchaseInvoiceEntity()


### PR DESCRIPTION
This commit adds some missing data for working with time_entries:
- Adds the **`Project`** entity
- Adds `user`, `project` and `detail` sub-entities to **`TimeEntry`**