### PR TITLE
Update Search trait for per_page & page attributes

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Search.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Search.php
@@ -13,9 +13,9 @@ trait Search
     public function search($query, $perPage = null, $page = null)
     {
         $result = $this->connection()->get($this->getEndpoint(), [
-            'query' => $query, 
-            'per_page' => $perPage, 
-            'page' => $page
+            'query' => $query,
+            'per_page' => $perPage,
+            'page' => $page,
         ], true);
 
         return $this->collectionFromResult($result);

--- a/src/Picqer/Financials/Moneybird/Actions/Search.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Search.php
@@ -10,9 +10,13 @@ trait Search
     /**
      * @return mixed
      */
-    public function search($query)
+    public function search($query, $perPage = null, $page = null)
     {
-        $result = $this->connection()->get($this->getEndpoint(), ['query' => $query], true);
+        $result = $this->connection()->get($this->getEndpoint(), [
+            'query' => $query, 
+            'per_page' => $perPage, 
+            'page' => $page
+        ], true);
 
         return $this->collectionFromResult($result);
     }


### PR DESCRIPTION
Based on the examples below from the Moneybird Docs, the search trait can be updated to allow `per_page` & `page` as an attribute:
- https://developer.moneybird.com/api/contacts/#get_contacts_example2
- https://developer.moneybird.com/api/products/#get_products_example3