### PR TITLE
Filterable changed to be useable for Contacts

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -21,7 +21,7 @@ trait Filterable
             $filterList[] = $key . ':' . $value;
         }
 
-        $result = $this->connection()->get($this->getEndpoint(), ['filter' => implode(',', $filterList)]);
+        $result = $this->connection()->get($this->getFilterEndpoint(), ['filter' => implode(',', $filterList)]);
 
         return $this->collectionFromResult($result);
     }
@@ -39,7 +39,7 @@ trait Filterable
             $filterList[] = $key . ':' . $value;
         }
 
-        $result = $this->connection()->get($this->getEndpoint(), ['filter' => implode(',', $filterList)], true);
+        $result = $this->connection()->get($this->getFilterEndpoint(), ['filter' => implode(',', $filterList)], true);
 
         return $this->collectionFromResult($result);
     }

--- a/src/Picqer/Financials/Moneybird/Entities/Contact.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Contact.php
@@ -2,6 +2,7 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Actions\Noteable;
@@ -20,7 +21,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class Contact extends Model
 {
-    use Search, FindAll, FindOne, Storable, Removable, Synchronizable, Noteable;
+    use Search, FindAll, FindOne, Storable, Removable, Filterable, Synchronizable, Noteable;
 
     /**
      * @var array
@@ -72,6 +73,11 @@ class Contact extends Model
      * @var string
      */
     protected $endpoint = 'contacts';
+
+    /**
+     * @var string
+     */
+    protected $filter_endpoint = 'contacts/filter';
 
     /**
      * @var string

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -42,6 +42,11 @@ abstract class Model
     protected $endpoint = '';
 
     /**
+     * @var string The Filter URL endpoint of this model
+     */
+    protected $filter_endpoint = '';
+
+    /**
      * @var string Name of the primary key for this model
      */
     protected $primaryKey = 'id';
@@ -442,6 +447,14 @@ abstract class Model
     public function getEndpoint()
     {
         return $this->endpoint;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilterEndpoint()
+    {
+        return $this->filter_endpoint ?? $this->endpoint;
     }
 
     /**


### PR DESCRIPTION
I've changed the way Filterable gets the endpoint, so endpoints can be overridden in the model. Contacts uses the same pattern, but a different endpoint than Sales Invoices. So being able to override the filter endpoint seems like the fastest solution.

Closes #238 