### PR TITLE
Replace deprecated rewind_body with Message::rewindBody

### DIFF
--- a/src/Picqer/Financials/Moneybird/Connection.php
+++ b/src/Picqer/Financials/Moneybird/Connection.php
@@ -414,7 +414,7 @@ class Connection
     private function parseResponse(Response $response)
     {
         try {
-            Psr7\rewind_body($response);
+            Psr7\Message::rewindBody($response);
             $json = json_decode($response->getBody()->getContents(), true);
 
             return $json;
@@ -477,7 +477,7 @@ class Connection
         $response = $this->client()->post($this->getTokenUrl(), $body);
 
         if ($response->getStatusCode() == 200) {
-            Psr7\rewind_body($response);
+            Psr7\Message::rewindBody($response);
             $body = json_decode($response->getBody()->getContents(), true);
 
             if (json_last_error() === JSON_ERROR_NONE) {
@@ -512,7 +512,7 @@ class Connection
             return new ApiException('Response is NULL.', 0, $exception);
         }
 
-        Psr7\rewind_body($response);
+        Psr7\Message::rewindBody($response);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true);
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -112,7 +112,7 @@ class ConnectionTest extends TestCase
         $request = $this->getRequestFromHistoryContainer();
         $this->assertEquals('POST', $request->getMethod());
 
-        Psr7\rewind_body($request);
+        Psr7\Message::rewindBody($request);
         $this->assertEquals(
             'redirect_uri=testRedirectUrl&grant_type=authorization_code&client_id=testClientId&client_secret=testClientSecret&code=testAuthorizationCode',
             $request->getBody()->getContents()


### PR DESCRIPTION
rewind_body will be removed in guzzlehttp/psr7:2.0. Usage of Message::rewindBody is adviced instead.