### PR TITLE
Allow updating 'update_contact' in SalesInvoice

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -33,6 +33,7 @@ class SalesInvoice extends Model
         'id',
         'administration_id',
         'contact_id',
+        'update_contact',
         'contact',
         'invoice_id',
         'invoice_sequence_id',


### PR DESCRIPTION
When an invoice has already been sent and you change the `contact_id`, the invoice won't be updated unless you specifically ask for it.

This can be done by sending `update_contact=true` with the update/patch request. This PR makes it possible to do so.

Moneybird documentation link: https://developer.moneybird.com/api/sales_invoices/#patch_sales_invoices_id

Thank you for the great work on this library.