### PR TITLE
Filterable is not working on models with only an endpoint defined

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -454,7 +454,7 @@ abstract class Model
      */
     public function getFilterEndpoint()
     {
-        return $this->filter_endpoint ?? $this->endpoint;
+        return $this->filter_endpoint ?: $this->endpoint;
     }
 
     /**


### PR DESCRIPTION
both variables are set, so ?? wil not work correct

it looks like this for me:

```
https://moneybird.com/api/v2/123/.json?filter=period%3A20210730..20210730%2Cstate%3Ascheduled%7Copen%7Cpending_payment%7Clate%7Creminded%7Cpaid%7Cuncollectible
```