### PR TITLE
Fix SalesInvoice filtering

### DIFF
--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -44,7 +44,7 @@ abstract class Model
     /**
      * @var string The Filter URL endpoint of this model
      */
-    protected $filter_endpoint = '';
+    protected $filter_endpoint;
 
     /**
      * @var string Name of the primary key for this model


### PR DESCRIPTION
The default (empty string) of [Model::$filter_endpoint](https://github.com/picqer/moneybird-php-client/blob/d0a1c51dfd572950878c053d8d8156ba66901fcf/src/Picqer/Financials/Moneybird/Model.php#L47) passes the null coalescing functionality of [getFilterEndpoint()](https://github.com/picqer/moneybird-php-client/blob/d0a1c51dfd572950878c053d8d8156ba66901fcf/src/Picqer/Financials/Moneybird/Model.php#L457), causing the [SalesInvoice::$endpoint](https://github.com/picqer/moneybird-php-client/blob/d0a1c51dfd572950878c053d8d8156ba66901fcf/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php#L88) property to be never used, breaking the filter URL with an error like:

```
[GuzzleHttp\Exception\ClientException (404)]                                                                                                              
  Client error: `GET https://moneybird.com/api/v2/XYZ/.json?filter=contact_id%3A1234` resulted in a `404 Not Found` response:  
  404 Not Found    
```
