### PR TITLE
Add prices_are_incl_tax to Estimate

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -72,6 +72,7 @@ class Estimate extends Model
         'attachments',
         'events',
         'tax_totals',
+        'prices_are_incl_tax',
     ];
 
     /**

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -114,9 +114,9 @@ class Estimate extends Model
     /**
      * Instruct Moneybird to send the estimate to the contact.
      *
-     * @param string|SendInvoiceOptions $deliveryMethodOrOptions
-     *
+     * @param  string|SendInvoiceOptions  $deliveryMethodOrOptions
      * @return $this
+     *
      * @throws ApiException
      */
     public function sendEstimate($deliveryMethodOrOptions = SendInvoiceOptions::METHOD_EMAIL)


### PR DESCRIPTION
Adds `prices_are_incl_tax` to fillable for `Estimate.

Reference: https://developer.moneybird.com/api/estimates/#post_estimates