### PR TITLE
Add Filterable trait to TaxRate

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Synchronizable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Synchronizable.php
@@ -9,6 +9,13 @@ trait Synchronizable
 {
     use BaseTrait;
 
+    public function getFillable()
+    {
+        return array_merge(parent::getFillable(), [
+            'version',
+        ]);
+    }
+
     /**
      * @param  array  $filters
      * @return mixed

--- a/src/Picqer/Financials/Moneybird/Entities/Administration.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Administration.php
@@ -5,16 +5,20 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Administration.
+ * @property string id
+ * @property string name
+ * @property string language
+ * @property string currency
+ * @property string country
+ * @property string time_zone
  */
 class Administration extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -24,8 +28,6 @@ class Administration extends Model
         'time_zone',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'administrations';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Contact.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Contact.php
@@ -13,20 +13,55 @@ use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Contact.
- *
- * @property string $id
- * @property ContactCustomField[] $custom_fields
- * @property ContactPeople[] $contact_people
+ * @property string id
+ * @property string company_name
+ * @property string firstname
+ * @property string lastname
+ * @property string attention
+ * @property string address1
+ * @property string address2
+ * @property string zipcode
+ * @property string city
+ * @property string country
+ * @property string email
+ * @property string phone
+ * @property string delivery_method
+ * @property string customer_id
+ * @property string tax_number
+ * @property string chamber_of_commerce
+ * @property string bank_account
+ * @property string send_invoices_to_attention
+ * @property string send_invoices_to_email
+ * @property string send_estimates_to_attention
+ * @property string send_estimates_to_email
+ * @property string sepa_active
+ * @property string sepa_iban
+ * @property string sepa_iban_account_name
+ * @property string sepa_bic
+ * @property string sepa_mandate_id
+ * @property string sepa_mandate_date
+ * @property string sepa_sequence_type
+ * @property string credit_card_number
+ * @property string credit_card_reference
+ * @property string credit_card_type
+ * @property string invoice_workflow_id
+ * @property string estimate_workflow_id
+ * @property string email_ubl
+ * @property string tax_number_validated_at
+ * @property string created_at
+ * @property string updated_at
+ * @property string notes
+ * @property string custom_fields
+ * @property string contact_people
+ * @property string version
  */
 class Contact extends Model
 {
     use Search, FindAll, FindOne, Storable, Removable, Filterable, Synchronizable, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'company_name',
@@ -71,24 +106,16 @@ class Contact extends Model
         'version',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'contacts';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'contact';
 
-    /**
-     * @var string
-     */
+    
     protected $filter_endpoint = 'contacts/filter';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'custom_fields' => [
             'entity' => ContactCustomField::class,
@@ -100,12 +127,7 @@ class Contact extends Model
         ],
     ];
 
-    /**
-     * @param  string|int  $customerId
-     * @return static
-     *
-     * @throws ApiException
-     */
+    
     public function findByCustomerId($customerId)
     {
         $result = $this->connection()->get($this->getEndpoint() . '/customer_id/' . urlencode($customerId));

--- a/src/Picqer/Financials/Moneybird/Entities/ContactCustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ContactCustomField.php
@@ -4,18 +4,15 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class ContactCustomField.
- *
- * @property string $id
- * @property string $name
- * @property string $value
+ * @property string id
+ * @property string name
+ * @property string value
  */
 class ContactCustomField extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',

--- a/src/Picqer/Financials/Moneybird/Entities/ContactPeople.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ContactPeople.php
@@ -4,12 +4,11 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class ContactPeople.
- *
- * @property string $id
- * @property string $administration_id
- * @property string $firstname
+ * @property string id
+ * @property string administration_id
+ * @property string firstname
  * @property string lastname
  * @property string phone
  * @property string email
@@ -20,9 +19,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class ContactPeople extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'administration_id',

--- a/src/Picqer/Financials/Moneybird/Entities/CustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/CustomField.php
@@ -5,24 +5,23 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class CustomField.
+ * @property string id
+ * @property string name
+ * @property string source
  */
 class CustomField extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
         'source',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'custom_fields';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/DocumentStyle.php
+++ b/src/Picqer/Financials/Moneybird/Entities/DocumentStyle.php
@@ -5,16 +5,37 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class DocumentStyle.
+ * @property string id
+ * @property string name
+ * @property string identity_id
+ * @property string default
+ * @property string logo_hash
+ * @property string logo_container_full_width
+ * @property string logo_display_width
+ * @property string logo_position
+ * @property string background_hash
+ * @property string paper_size
+ * @property string address_position
+ * @property string font_size
+ * @property string font_family
+ * @property string print_on_stationary
+ * @property string custom_css
+ * @property string invoice_sender_address
+ * @property string invoice_metadata_left
+ * @property string invoice_metadata_right
+ * @property string estimate_sender_address
+ * @property string estimate_metadata_left
+ * @property string estimate_metadata_right
+ * @property string created_at
+ * @property string updated_at
  */
 class DocumentStyle extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -41,8 +62,6 @@ class DocumentStyle extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'document_styles';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -14,21 +14,57 @@ use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Entities\SalesInvoice\SendInvoiceOptions;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Contact.
- *
- * @property int $id
- * @property string $company_name
- * @property string $first_name
- * @property string $last_name
+ * @property string id
+ * @property string administration_id
+ * @property string contact_id
+ * @property string contact
+ * @property string estimate_id
+ * @property string workflow_id
+ * @property string document_style_id
+ * @property string identity_id
+ * @property string draft_id
+ * @property string state
+ * @property string estimate_date
+ * @property string due_date
+ * @property string reference
+ * @property string language
+ * @property string currency
+ * @property string exchange_rate
+ * @property string discount
+ * @property string original_estimate_id
+ * @property string show_tax
+ * @property string sign_online
+ * @property string sent_at
+ * @property string accepted_at
+ * @property string rejected_at
+ * @property string archived_at
+ * @property string created_at
+ * @property string updated_at
+ * @property string public_view_code
+ * @property string version
+ * @property string pre_text
+ * @property string post_text
+ * @property string details
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
+ * @property string total_discount
+ * @property string url
+ * @property string custom_fields
+ * @property string notes
+ * @property string attachments
+ * @property string events
+ * @property string tax_totals
+ * @property string prices_are_incl_tax
  */
 class Estimate extends Model
 {
     use FindAll, FindOne, Storable, Removable, Synchronizable, Filterable, Downloadable, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'administration_id',
@@ -75,19 +111,13 @@ class Estimate extends Model
         'prices_are_incl_tax',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'estimates';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'estimate';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'custom_fields' => [
             'entity' => SalesInvoiceCustomField::class,
@@ -111,14 +141,7 @@ class Estimate extends Model
         ],
     ];
 
-    /**
-     * Instruct Moneybird to send the estimate to the contact.
-     *
-     * @param  string|SendInvoiceOptions  $deliveryMethodOrOptions
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function sendEstimate($deliveryMethodOrOptions = SendInvoiceOptions::METHOD_EMAIL)
     {
         if (is_string($deliveryMethodOrOptions)) {

--- a/src/Picqer/Financials/Moneybird/Entities/EstimateEvent.php
+++ b/src/Picqer/Financials/Moneybird/Entities/EstimateEvent.php
@@ -4,8 +4,16 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\Event;
 
+
 /**
- * Class EstimateEvent.
+ * @property string administration_id
+ * @property string user_id
+ * @property string action
+ * @property string link_entity_id
+ * @property string link_entity_type
+ * @property string data
+ * @property string created_at
+ * @property string updated_at
  */
 class EstimateEvent extends Event
 {

--- a/src/Picqer/Financials/Moneybird/Entities/EstimateTaxTotal.php
+++ b/src/Picqer/Financials/Moneybird/Entities/EstimateTaxTotal.php
@@ -4,14 +4,17 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class EstimateTaxTotal.
+ * @property string tax_rate_id
+ * @property string taxable_amount
+ * @property string taxable_amount_base
+ * @property string tax_amount
+ * @property string tax_amount_base
  */
 class EstimateTaxTotal extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'tax_rate_id',
         'taxable_amount',

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -13,19 +13,40 @@ use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Connection;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class ExternalSalesInvoice.
- *
- * @property string $id
- * @property Contact $contact
+ * @property string id
+ * @property string contact_id
+ * @property string reference
+ * @property string date
+ * @property string due_date
+ * @property string entry_number
+ * @property string state
+ * @property string currency
+ * @property string prices_are_incl_tax
+ * @property string source
+ * @property string source_url
+ * @property string origin
+ * @property string paid_at
+ * @property string total_paid
+ * @property string total_unpaid
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
+ * @property string created_at
+ * @property string updated_at
+ * @property string details
+ * @property string payments
+ * @property string notes
+ * @property string attachments
+ * @property string version
  */
 class ExternalSalesInvoice extends Model
 {
     use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable, Attachment;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -55,26 +76,18 @@ class ExternalSalesInvoice extends Model
         'version',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'external_sales_invoices';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'external_sales_invoice';
 
-    /**
-     * @var array
-     */
+    
     protected $singleNestedEntities = [
         'contact' => Contact::class,
     ];
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'details' => [
             'entity' => ExternalSalesInvoiceDetail::class,

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceDetail.php
@@ -4,8 +4,26 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoiceDetail;
 
+
 /**
- * Class ExternalSalesInvoiceDetail.
+ * @property string id
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string amount
+ * @property string amount_decimal
+ * @property string description
+ * @property string period
+ * @property string price
+ * @property string row_order
+ * @property string total_price_excl_tax_with_discount
+ * @property string total_price_excl_tax_with_discount_base
+ * @property string tax_report_reference
+ * @property string created_at
+ * @property string updated_at
+ * @property string product_id
+ * @property string project_id
+ * @property string _destroy
+ * @property string project_id
  */
 class ExternalSalesInvoiceDetail extends InvoiceDetail
 {

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoicePayment.php
@@ -4,8 +4,24 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoicePayment;
 
+
 /**
- * Class ExternalSalesInvoicePayment.
+ * @property string id
+ * @property string invoice_type
+ * @property string invoice_id
+ * @property string financial_account_id
+ * @property string user_id
+ * @property string payment_transaction_id
+ * @property string price
+ * @property string price_base
+ * @property string payment_date
+ * @property string credit_invoice_id
+ * @property string financial_mutation_id
+ * @property string transaction_identifier
+ * @property string manual_payment_action
+ * @property string ledger_account_id
+ * @property string created_at
+ * @property string updated_at
  */
 class ExternalSalesInvoicePayment extends InvoicePayment
 {

--- a/src/Picqer/Financials/Moneybird/Entities/FinancialAccount.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialAccount.php
@@ -5,16 +5,23 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class FinancialAccount.
+ * @property string id
+ * @property string type
+ * @property string name
+ * @property string identifier
+ * @property string currency
+ * @property string provider
+ * @property string active
+ * @property string created_at
+ * @property string updated_at
  */
 class FinancialAccount extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'type',
@@ -27,8 +34,6 @@ class FinancialAccount extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'financial_accounts';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
@@ -8,20 +8,35 @@ use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class FinancialMutation.
- *
- * @property LedgerAccountBooking[] $ledger_account_bookings
+ * @property string id
+ * @property string amount
+ * @property string code
+ * @property string date
+ * @property string message
+ * @property string contra_account_name
+ * @property string contra_account_number
+ * @property string state
+ * @property string amount_open
+ * @property string sepa_fields
+ * @property string batch_reference
+ * @property string financial_account_id
+ * @property string currency
+ * @property string original_amount
+ * @property string created_at
+ * @property string updated_at
+ * @property string financial_statement_id
+ * @property string processed_at
+ * @property string payments
+ * @property string ledger_account_bookings
+ * @property string account_servicer_transaction_id
  */
 class FinancialMutation extends Model
 {
     use FindAll, Filterable, Synchronizable;
 
-    /**
-     * @see https://developer.moneybird.com/api/financial_mutations/#patch_financial_mutations_id_link_booking
-     *
-     * @var array
-     */
+    
     private static $allowedBookingTypesToLinkToFinancialMutation = [
         'Document',
         'ExternalSalesInvoice',
@@ -36,20 +51,14 @@ class FinancialMutation extends Model
         'SalesInvoice',
     ];
 
-    /**
-     * @see https://developer.moneybird.com/api/financial_mutations/#delete_financial_mutations_id_unlink_booking
-     *
-     * @var array
-     */
+    
     private static $allowedBookingTypesToUnlinkFromFinancialMutation = [
 
         'LedgerAccountBooking',
         'Payment',
     ];
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'amount',
@@ -74,14 +83,10 @@ class FinancialMutation extends Model
         'account_servicer_transaction_id',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'financial_mutations';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'ledger_account_bookings' => [
             'entity' => LedgerAccountBooking::class,
@@ -89,17 +94,7 @@ class FinancialMutation extends Model
         ],
     ];
 
-    /**
-     * @param  string  $bookingType
-     * @param  string | int  $bookingId
-     * @param  string | float  $priceBase
-     * @param  string | float  $price
-     * @param  string  $description
-     * @param  string  $paymentBatchIdentifier
-     * @return int
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function linkToBooking($bookingType, $bookingId, $priceBase, $price = null, $description = null, $paymentBatchIdentifier = null)
     {
         if (! in_array($bookingType, self::$allowedBookingTypesToLinkToFinancialMutation, true)) {
@@ -124,13 +119,7 @@ class FinancialMutation extends Model
         return $this->connection->patch($this->endpoint . '/' . $this->id . '/link_booking', json_encode($parameters));
     }
 
-    /**
-     * @param  string  $bookingType
-     * @param  string | int  $bookingId
-     * @return array
-     *
-     * @throws ApiException
-     */
+    
     public function unlinkFromBooking($bookingType, $bookingId)
     {
         if (! in_array($bookingType, self::$allowedBookingTypesToUnlinkFromFinancialMutation, true)) {

--- a/src/Picqer/Financials/Moneybird/Entities/FinancialStatement.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialStatement.php
@@ -6,16 +6,22 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class FinancialStatement.
+ * @property string id
+ * @property string financial_account_id
+ * @property string reference
+ * @property string official_date
+ * @property string official_balance
+ * @property string importer_service
+ * @property string financial_mutations
+ * @property string update_journal_entries
  */
 class FinancialStatement extends Model
 {
     use Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'financial_account_id',
@@ -27,19 +33,13 @@ class FinancialStatement extends Model
         'update_journal_entries',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'financial_statements';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'financial_statement';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'financial_mutations' => [
             'entity' => FinancialMutation::class,

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
@@ -10,16 +10,26 @@ use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class GeneralDocument.
+ * @property string id
+ * @property string contact_id
+ * @property string reference
+ * @property string date
+ * @property string due_date
+ * @property string entry_number
+ * @property string state
+ * @property string exchange_rate
+ * @property string created_at
+ * @property string updated_at
+ * @property string notes
+ * @property string attachments
  */
 class GeneralDocument extends Model
 {
     use FindAll, FindOne, Storable, Removable, Synchronizable, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -35,13 +45,9 @@ class GeneralDocument extends Model
         'attachments',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'documents/general_documents';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'general_document';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocument.php
@@ -9,16 +9,22 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class GeneralJournalDocument.
+ * @property string id
+ * @property string reference
+ * @property string date
+ * @property string created_at
+ * @property string updated_at
+ * @property string general_journal_document_entries
+ * @property string notes
+ * @property string attachments
  */
 class GeneralJournalDocument extends Model
 {
     use FindAll, FindOne, Storable, Removable, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'reference',
@@ -30,19 +36,13 @@ class GeneralJournalDocument extends Model
         'attachments',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'documents/general_journal_documents';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'general_journal_document';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'general_journal_document_entries' => [
             'entity' => GeneralJournalDocumentEntry::class,

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocumentEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocumentEntry.php
@@ -4,14 +4,23 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class InvoiceDetail.
+ * @property string id
+ * @property string administration_id
+ * @property string ledger_account_id
+ * @property string contact_id
+ * @property string description
+ * @property string debit
+ * @property string credit
+ * @property string project_id
+ * @property string row_order
+ * @property string created_at
+ * @property string updated_at
  */
 class GeneralJournalDocumentEntry extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'administration_id',

--- a/src/Picqer/Financials/Moneybird/Entities/Identity.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Identity.php
@@ -8,16 +8,29 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Identity.
+ * @property string id
+ * @property string company_name
+ * @property string city
+ * @property string country
+ * @property string zipcode
+ * @property string address1
+ * @property string address2
+ * @property string email
+ * @property string phone
+ * @property string bank_account_name
+ * @property string bank_account_number
+ * @property string bank_account_bic
+ * @property string custom_fields
+ * @property string created_at
+ * @property string updated_at
  */
 class Identity extends Model
 {
     use FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'company_name',
@@ -36,13 +49,9 @@ class Identity extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'identities';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'identity';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ImportMapping.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ImportMapping.php
@@ -6,21 +6,21 @@ use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Actions\FindOne;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class ImportMapping.
+ * @property string administration_id
+ * @property string entity_type
+ * @property string old_id
+ * @property string new_id
  */
 class ImportMapping extends Model
 {
     use FindAll, FindOne;
 
-    /**
-     * @var string|null
-     */
+    
     protected $type;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'administration_id',
         'entity_type',
@@ -28,19 +28,10 @@ class ImportMapping extends Model
         'new_id',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'import_mappings';
 
-    /**
-     * @param  string  $type  The type of import mapping to request
-     *
-     * Type should be any of: financial_account bank_mutation contact document_attachment general_journal identity
-     * incoming_invoice attachment payment history invoice_attachment transaction ledger_account tax_rate product
-     * print_invoice recurring_template invoice workflow document_style
-     * @return $this
-     */
+    
     public function setType($type)
     {
         $this->type = $type;

--- a/src/Picqer/Financials/Moneybird/Entities/LedgerAccount.php
+++ b/src/Picqer/Financials/Moneybird/Entities/LedgerAccount.php
@@ -8,16 +8,22 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class LedgerAccount.
+ * @property string id
+ * @property string name
+ * @property string account_type
+ * @property string account_id
+ * @property string parent_id
+ * @property string allowed_document_types
+ * @property string created_at
+ * @property string updated_at
  */
 class LedgerAccount extends Model
 {
     use FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -29,13 +35,9 @@ class LedgerAccount extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'ledger_accounts';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'ledger_account';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/LedgerAccountBooking.php
+++ b/src/Picqer/Financials/Moneybird/Entities/LedgerAccountBooking.php
@@ -4,22 +4,19 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class LedgerAccountBooking.
- *
- * @property string $id
- * @property string $administration_id
- * @property string $ledger_account_id
- * @property string $description
- * @property string $price
- * @property string $created_at
- * @property string $updated_at
+ * @property string id
+ * @property string administration_id
+ * @property string ledger_account_id
+ * @property string description
+ * @property string price
+ * @property string created_at
+ * @property string updated_at
  */
 class LedgerAccountBooking extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'administration_id',

--- a/src/Picqer/Financials/Moneybird/Entities/Note.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Note.php
@@ -4,19 +4,25 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Note.
- *
- * @property string $id
- * @property string $note
- * @property bool $todo
- * @property string $assignee_id
+ * @property string id
+ * @property string note
+ * @property string todo
+ * @property string assignee_id
+ * @property string id
+ * @property string note
+ * @property string todo
+ * @property string assignee_id
+ * @property string user_id
+ * @property string completed_by_id
+ * @property string completed_at
+ * @property string todo_type
+ * @property string created_at
  */
 class Note extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'note',
@@ -33,8 +39,6 @@ class Note extends Model
         'created_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'note';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Note.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Note.php
@@ -22,6 +22,15 @@ class Note extends Model
         'note',
         'todo',
         'assignee_id',
+        'id',
+        'note',
+        'todo',
+        'assignee_id',
+        'user_id',
+        'completed_by_id',
+        'completed_at',
+        'todo_type',
+        'created_at',
     ];
 
     /**

--- a/src/Picqer/Financials/Moneybird/Entities/Product.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Product.php
@@ -9,16 +9,24 @@ use Picqer\Financials\Moneybird\Actions\Search;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Product.
+ * @property string id
+ * @property string description
+ * @property string price
+ * @property string currency
+ * @property string frequency
+ * @property string frequency_type
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string created_at
+ * @property string updated_at
  */
 class Product extends Model
 {
     use Search, FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'description',
@@ -32,13 +40,9 @@ class Product extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'products';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'product';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Project.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Project.php
@@ -8,16 +8,18 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Project.
+ * @property string id
+ * @property string name
+ * @property string state
+ * @property string budget
  */
 class Project extends Model
 {
     use FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -25,13 +27,9 @@ class Project extends Model
         'budget',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'projects';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'project';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
@@ -13,16 +13,39 @@ use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class PurchaseInvoice.
+ * @property string id
+ * @property string contact_id
+ * @property string reference
+ * @property string date
+ * @property string due_date
+ * @property string entry_number
+ * @property string state
+ * @property string currency
+ * @property string exchange_rate
+ * @property string revenue_invoice
+ * @property string prices_are_incl_tax
+ * @property string origin
+ * @property string paid_at
+ * @property string tax_number
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
+ * @property string created_at
+ * @property string updated_at
+ * @property string details
+ * @property string payments
+ * @property string notes
+ * @property string attachments
+ * @property string version
  */
 class PurchaseInvoice extends Model
 {
     use FindAll, FindOne, Storable, Removable, Filterable, Synchronizable, Attachment, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -51,26 +74,18 @@ class PurchaseInvoice extends Model
         'version',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'documents/purchase_invoices';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'purchase_invoice';
 
-    /**
-     * @var array
-     */
+    
     protected $singleNestedEntities = [
         'contact' => Contact::class,
     ];
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'details' => [
             'entity' => PurchaseInvoiceDetail::class,
@@ -86,14 +101,7 @@ class PurchaseInvoice extends Model
         ],
     ];
 
-    /**
-     * Register a payment for the current purchase invoice.
-     *
-     * @param  PurchaseInvoicePayment  $purchaseInvoicePayment  (payment_date and price are required)
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function registerPayment(PurchaseInvoicePayment $purchaseInvoicePayment)
     {
         if (! isset($purchaseInvoicePayment->payment_date)) {

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
@@ -80,6 +80,10 @@ class PurchaseInvoice extends Model
             'entity' => PurchaseInvoicePayment::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
         ],
+        'notes' => [
+            'entity' => Note::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
     ];
 
     /**

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoiceDetail.php
@@ -4,8 +4,26 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoiceDetail;
 
+
 /**
- * Class PurchaseInvoiceDetail.
+ * @property string id
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string amount
+ * @property string amount_decimal
+ * @property string description
+ * @property string period
+ * @property string price
+ * @property string row_order
+ * @property string total_price_excl_tax_with_discount
+ * @property string total_price_excl_tax_with_discount_base
+ * @property string tax_report_reference
+ * @property string created_at
+ * @property string updated_at
+ * @property string product_id
+ * @property string project_id
+ * @property string _destroy
+ * @property string project_id
  */
 class PurchaseInvoiceDetail extends InvoiceDetail
 {

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoicePayment.php
@@ -4,18 +4,28 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoicePayment;
 
+
 /**
- * Class SalesInvoicePayment.
+ * @property string id
+ * @property string invoice_type
+ * @property string invoice_id
+ * @property string financial_account_id
+ * @property string user_id
+ * @property string payment_transaction_id
+ * @property string price
+ * @property string price_base
+ * @property string payment_date
+ * @property string credit_invoice_id
+ * @property string financial_mutation_id
+ * @property string transaction_identifier
+ * @property string manual_payment_action
+ * @property string ledger_account_id
+ * @property string created_at
+ * @property string updated_at
  */
 class PurchaseInvoicePayment extends InvoicePayment
 {
-    /**
-     * Delete the current purchase invoice payment.
-     *
-     * @return mixed
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function delete()
     {
         return $this->connection()->delete('/documents/purchase_invoices/' . urlencode($this->invoice_id) . '/payments/' . urlencode($this->id));

--- a/src/Picqer/Financials/Moneybird/Entities/Receipt.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Receipt.php
@@ -11,16 +11,38 @@ use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Receipt.
+ * @property string id
+ * @property string contact_id
+ * @property string reference
+ * @property string date
+ * @property string due_date
+ * @property string entry_number
+ * @property string state
+ * @property string currency
+ * @property string exchange_rate
+ * @property string revenue_invoice
+ * @property string prices_are_incl_tax
+ * @property string origin
+ * @property string paid_at
+ * @property string tax_number
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
+ * @property string created_at
+ * @property string updated_at
+ * @property string details
+ * @property string payments
+ * @property string notes
+ * @property string attachments
  */
 class Receipt extends Model
 {
     use FindAll, FindOne, Storable, Removable, Attachment, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -48,19 +70,13 @@ class Receipt extends Model
         'attachments',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'documents/receipts';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'receipt';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'details' => [
             'entity' => ReceiptDetail::class,
@@ -68,14 +84,7 @@ class Receipt extends Model
         ],
     ];
 
-    /**
-     * Register a payment for the current purchase invoice.
-     *
-     * @param  ReceiptPayment  $receiptPayment  (payment_date and price are required)
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function registerPayment(ReceiptPayment $receiptPayment)
     {
         if (! isset($receiptPayment->payment_date)) {

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptDetail.php
@@ -4,14 +4,21 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class ReceiptDetail.
+ * @property string id
+ * @property string description
+ * @property string period
+ * @property string price
+ * @property string amount
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string row_order
+ * @property string _destroy
  */
 class ReceiptDetail extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'description',

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptPayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptPayment.php
@@ -4,14 +4,25 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class InvoicePayment.
+ * @property string id
+ * @property string invoice_type
+ * @property string invoice_id
+ * @property string financial_account_id
+ * @property string user_id
+ * @property string payment_transaction_id
+ * @property string price
+ * @property string price_base
+ * @property string payment_date
+ * @property string credit_invoice_id
+ * @property string financial_mutation_id
+ * @property string created_at
+ * @property string updated_at
  */
 class ReceiptPayment extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'invoice_type',
@@ -28,8 +39,6 @@ class ReceiptPayment extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'payment';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoice.php
@@ -11,16 +11,49 @@ use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class RecurringSalesInvoice.
+ * @property string id
+ * @property string contact_id
+ * @property string contact
+ * @property string workflow_id
+ * @property string state
+ * @property string start_date
+ * @property string invoice_date
+ * @property string last_date
+ * @property string payment_conditions
+ * @property string reference
+ * @property string language
+ * @property string currency
+ * @property string discount
+ * @property string first_due_interval
+ * @property string auto_send
+ * @property string mergeable
+ * @property string sending_scheduled_at
+ * @property string sending_scheduled_user_id
+ * @property string frequency_type
+ * @property string frequency
+ * @property string created_at
+ * @property string updated_at
+ * @property string details
+ * @property string notes
+ * @property string attachments
+ * @property string has_desired_count
+ * @property string desired_count
+ * @property string version
+ * @property string active
+ * @property string custom_fields
+ * @property string prices_are_incl_tax
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
  */
 class RecurringSalesInvoice extends Model
 {
     use FindAll, FindOne, Storable, Removable, Filterable, Synchronizable, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -59,19 +92,13 @@ class RecurringSalesInvoice extends Model
         'total_price_incl_tax_base',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'recurring_sales_invoices';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'recurring_sales_invoice';
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'details' => [
             'entity' => RecurringSalesInvoiceDetail::class,

--- a/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoiceCustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoiceCustomField.php
@@ -2,8 +2,10 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+
 /**
- * Class RecurringSalesInvoiceCustomField.
+ * @property string id
+ * @property string value
  */
 class RecurringSalesInvoiceCustomField extends Generic\CustomField
 {

--- a/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/RecurringSalesInvoiceDetail.php
@@ -4,8 +4,26 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoiceDetail;
 
+
 /**
- * Class RecurringSalesInvoiceDetail.
+ * @property string id
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string amount
+ * @property string amount_decimal
+ * @property string description
+ * @property string period
+ * @property string price
+ * @property string row_order
+ * @property string total_price_excl_tax_with_discount
+ * @property string total_price_excl_tax_with_discount_base
+ * @property string tax_report_reference
+ * @property string created_at
+ * @property string updated_at
+ * @property string product_id
+ * @property string project_id
+ * @property string _destroy
+ * @property string project_id
  */
 class RecurringSalesInvoiceDetail extends InvoiceDetail
 {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -16,19 +16,64 @@ use Picqer\Financials\Moneybird\Entities\SalesInvoice\SendInvoiceOptions;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class SalesInvoice.
- *
- * @property string $id
- * @property Contact $contact
+ * @property string id
+ * @property string administration_id
+ * @property string contact_id
+ * @property string update_contact
+ * @property string contact
+ * @property string invoice_id
+ * @property string invoice_sequence_id
+ * @property string recurring_sales_invoice_id
+ * @property string workflow_id
+ * @property string document_style_id
+ * @property string identity_id
+ * @property string draft_id
+ * @property string state
+ * @property string invoice_date
+ * @property string due_date
+ * @property string first_due_interval
+ * @property string payment_conditions
+ * @property string payment_reference
+ * @property string reference
+ * @property string language
+ * @property string currency
+ * @property string discount
+ * @property string original_sales_invoice_id
+ * @property string paused
+ * @property string paid_at
+ * @property string sent_at
+ * @property string created_at
+ * @property string updated_at
+ * @property string public_view_code
+ * @property string version
+ * @property string details
+ * @property string payments
+ * @property string total_paid
+ * @property string total_unpaid
+ * @property string total_unpaid_base
+ * @property string prices_are_incl_tax
+ * @property string total_price_excl_tax
+ * @property string total_price_excl_tax_base
+ * @property string total_price_incl_tax
+ * @property string total_price_incl_tax_base
+ * @property string total_discount
+ * @property string marked_dubious_on
+ * @property string marked_uncollectible_on
+ * @property string url
+ * @property string payment_url
+ * @property string custom_fields
+ * @property string notes
+ * @property string attachments
+ * @property string events
+ * @property string tax_totals
  */
 class SalesInvoice extends Model
 {
     use FindAll, FindOne, Storable, Removable, Filterable, Downloadable, Synchronizable, Attachment, Noteable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'administration_id',
@@ -82,26 +127,18 @@ class SalesInvoice extends Model
         'tax_totals',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'sales_invoices';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'sales_invoice';
 
-    /**
-     * @var array
-     */
+    
     protected $singleNestedEntities = [
         'contact' => Contact::class,
     ];
 
-    /**
-     * @var array
-     */
+    
     protected $multipleNestedEntities = [
         'custom_fields' => [
             'entity' => SalesInvoiceCustomField::class,
@@ -129,14 +166,7 @@ class SalesInvoice extends Model
         ],
     ];
 
-    /**
-     * Instruct Moneybird to send the invoice to the contact.
-     *
-     * @param  string|SendInvoiceOptions  $deliveryMethodOrOptions
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function sendInvoice($deliveryMethodOrOptions = SendInvoiceOptions::METHOD_EMAIL)
     {
         if (is_string($deliveryMethodOrOptions)) {
@@ -162,14 +192,7 @@ class SalesInvoice extends Model
         return $this;
     }
 
-    /**
-     * Find SalesInvoice by invoice_id.
-     *
-     * @param  string|int  $invoiceId
-     * @return static
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function findByInvoiceId($invoiceId)
     {
         $result = $this->connection()->get($this->getEndpoint() . '/find_by_invoice_id/' . urlencode($invoiceId));
@@ -177,14 +200,7 @@ class SalesInvoice extends Model
         return $this->makeFromResponse($result);
     }
 
-    /**
-     * Register a payment for the current invoice.
-     *
-     * @param  SalesInvoicePayment  $salesInvoicePayment  (payment_date and price are required)
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function registerPayment(SalesInvoicePayment $salesInvoicePayment)
     {
         if (! isset($salesInvoicePayment->payment_date)) {
@@ -202,14 +218,7 @@ class SalesInvoice extends Model
         return $this;
     }
 
-    /**
-     * Delete a payment for the current invoice.
-     *
-     * @param  SalesInvoicePayment  $salesInvoicePayment  (id is required)
-     * @return $this
-     *
-     * @throws ApiException
-     */
+    
     public function deletePayment(SalesInvoicePayment $salesInvoicePayment)
     {
         if (! isset($salesInvoicePayment->id)) {
@@ -221,13 +230,7 @@ class SalesInvoice extends Model
         return $this;
     }
 
-    /**
-     * Create a credit invoice based on the current invoice.
-     *
-     * @return \Picqer\Financials\Moneybird\Entities\SalesInvoice
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function duplicateToCreditInvoice()
     {
         $response = $this->connection()->patch($this->getEndpoint() . '/' . $this->id . '/duplicate_creditinvoice',
@@ -237,13 +240,7 @@ class SalesInvoice extends Model
         return $this->makeFromResponse($response);
     }
 
-    /**
-     * Register a payment for a credit invoice.
-     *
-     * @return \Picqer\Financials\Moneybird\Entities\SalesInvoice
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function registerPaymentForCreditInvoice()
     {
         $response = $this->connection()->patch($this->getEndpoint() . '/' . $this->id . '/register_payment_creditinvoice',
@@ -253,13 +250,7 @@ class SalesInvoice extends Model
         return $this->makeFromResponse($response);
     }
 
-    /**
-     * Pauses the sales invoice. The automatic workflow steps will not be executed while the sales invoice is paused.
-     *
-     * @return bool
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function pauseWorkflow()
     {
         try {
@@ -275,13 +266,7 @@ class SalesInvoice extends Model
         return true;
     }
 
-    /**
-     * Resumes the sales invoice. The automatic workflow steps will execute again after resuming.
-     *
-     * @return bool
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function resumeWorkflow()
     {
         try {
@@ -297,13 +282,7 @@ class SalesInvoice extends Model
         return true;
     }
 
-    /**
-     * Download as UBL.
-     *
-     * @return string PDF file data
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function downloadUBL()
     {
         $response = $this->connection()->download($this->getEndpoint() . '/' . urlencode($this->id) . '/download_ubl');
@@ -311,13 +290,7 @@ class SalesInvoice extends Model
         return $response->getBody()->getContents();
     }
 
-    /**
-     * Download as Packaging slip.
-     *
-     * @return string PDF file data
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function downloadPackageSlip()
     {
         $response = $this->connection()->download($this->getEndpoint() . '/' . urlencode($this->id) . '/download_packing_slip_pdf');

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceCustomField.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceCustomField.php
@@ -2,8 +2,10 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+
 /**
- * Class SalesInvoiceCustomField.
+ * @property string id
+ * @property string value
  */
 class SalesInvoiceCustomField extends Generic\CustomField
 {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceDetail.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceDetail.php
@@ -4,8 +4,26 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoiceDetail;
 
+
 /**
- * Class SalesInvoiceDetail.
+ * @property string id
+ * @property string tax_rate_id
+ * @property string ledger_account_id
+ * @property string amount
+ * @property string amount_decimal
+ * @property string description
+ * @property string period
+ * @property string price
+ * @property string row_order
+ * @property string total_price_excl_tax_with_discount
+ * @property string total_price_excl_tax_with_discount_base
+ * @property string tax_report_reference
+ * @property string created_at
+ * @property string updated_at
+ * @property string product_id
+ * @property string project_id
+ * @property string _destroy
+ * @property string project_id
  */
 class SalesInvoiceDetail extends InvoiceDetail
 {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceEvent.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceEvent.php
@@ -4,8 +4,16 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\Event;
 
+
 /**
- * Class SalesInvoiceEvent.
+ * @property string administration_id
+ * @property string user_id
+ * @property string action
+ * @property string link_entity_id
+ * @property string link_entity_type
+ * @property string data
+ * @property string created_at
+ * @property string updated_at
  */
 class SalesInvoiceEvent extends Event
 {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoicePayment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoicePayment.php
@@ -4,8 +4,24 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Entities\Generic\InvoicePayment;
 
+
 /**
- * Class SalesInvoicePayment.
+ * @property string id
+ * @property string invoice_type
+ * @property string invoice_id
+ * @property string financial_account_id
+ * @property string user_id
+ * @property string payment_transaction_id
+ * @property string price
+ * @property string price_base
+ * @property string payment_date
+ * @property string credit_invoice_id
+ * @property string financial_mutation_id
+ * @property string transaction_identifier
+ * @property string manual_payment_action
+ * @property string ledger_account_id
+ * @property string created_at
+ * @property string updated_at
  */
 class SalesInvoicePayment extends InvoicePayment
 {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceReminder.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceReminder.php
@@ -4,14 +4,20 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class SalesInvoiceReminder.
+ * @property string contact_id
+ * @property string workflow_id
+ * @property string identity_id
+ * @property string document_style_id
+ * @property string sales_invoices
+ * @property string reminder_text
+ * @property string delivery_method
+ * @property string email_address
  */
 class SalesInvoiceReminder extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'contact_id',
         'workflow_id',
@@ -25,16 +31,10 @@ class SalesInvoiceReminder extends Model
 
     protected $endpoint = 'sales_invoices';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'sales_invoice_reminders';
 
-    /**
-     * Pushes the reminder.
-     *
-     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
-     */
+    
     public function send()
     {
         $aReminder = $this->json();

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceTaxTotal.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceTaxTotal.php
@@ -4,14 +4,17 @@ namespace Picqer\Financials\Moneybird\Entities;
 
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class SalesInvoiceTaxTotal.
+ * @property string tax_rate_id
+ * @property string taxable_amount
+ * @property string taxable_amount_base
+ * @property string tax_amount
+ * @property string tax_amount_base
  */
 class SalesInvoiceTaxTotal extends Model
 {
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'tax_rate_id',
         'taxable_amount',

--- a/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
@@ -23,6 +23,7 @@ class TaxRate extends Model
         'tax_rate_type',
         'show_tax',
         'active',
+        'country',
         'created_at',
         'updated_at',
     ];

--- a/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
@@ -6,16 +6,23 @@ use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class TaxRate.
+ * @property string id
+ * @property string name
+ * @property string percentage
+ * @property string tax_rate_type
+ * @property string show_tax
+ * @property string active
+ * @property string country
+ * @property string created_at
+ * @property string updated_at
  */
 class TaxRate extends Model
 {
     use FindAll, Filterable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -28,8 +35,6 @@ class TaxRate extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'tax_rates';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TaxRate.php
@@ -2,6 +2,7 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+use Picqer\Financials\Moneybird\Actions\Filterable;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
@@ -10,7 +11,7 @@ use Picqer\Financials\Moneybird\Model;
  */
 class TaxRate extends Model
 {
-    use FindAll;
+    use FindAll, Filterable;
 
     /**
      * @var array

--- a/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TimeEntry.php
@@ -8,13 +8,26 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+/**
+ * @property string id
+ * @property string user_id
+ * @property string user
+ * @property string started_at
+ * @property string ended_at
+ * @property string paused_duration
+ * @property string contact_id
+ * @property string project_id
+ * @property string project
+ * @property string detail_id
+ * @property string detail
+ * @property string description
+ * @property string billable
+ */
 class TimeEntry extends Model
 {
     use FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'user_id',
@@ -31,19 +44,13 @@ class TimeEntry extends Model
         'billable',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'time_entries';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'time_entry';
 
-    /**
-     * @var array
-     */
+    
     protected $singleNestedEntities = [
         'user' => User::class,
         'project' => Project::class,

--- a/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
@@ -9,16 +9,23 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class TypelessDocument.
+ * @property string id
+ * @property string contact_id
+ * @property string reference
+ * @property string date
+ * @property string state
+ * @property string origin
+ * @property string created_at
+ * @property string updated_at
+ * @property string attachments
  */
 class TypelessDocument extends Model
 {
     use Attachment, FindAll, FindOne, Storable, Removable;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'contact_id',
@@ -31,13 +38,9 @@ class TypelessDocument extends Model
         'attachments',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'documents/typeless_documents';
 
-    /**
-     * @var string
-     */
+    
     protected $namespace = 'typeless_document';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/User.php
+++ b/src/Picqer/Financials/Moneybird/Entities/User.php
@@ -5,16 +5,23 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class User.
+ * @property string id
+ * @property string name
+ * @property string created_at
+ * @property string updated_at
+ * @property string email
+ * @property string email_validated
+ * @property string language
+ * @property string time_zone
+ * @property string permissions
  */
 class User extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'name',
@@ -27,8 +34,6 @@ class User extends Model
         'permissions',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'users';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Webhook.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Webhook.php
@@ -7,8 +7,13 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Webhook.
+ * @property string id
+ * @property string url
+ * @property string events
+ * @property string last_http_status
+ * @property string last_http_body
  */
 class Webhook extends Model
 {
@@ -16,9 +21,7 @@ class Webhook extends Model
 
     const JSON_OPTIONS = 0;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'url',
@@ -27,8 +30,6 @@ class Webhook extends Model
         'last_http_body',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'webhooks';
 }

--- a/src/Picqer/Financials/Moneybird/Entities/Workflow.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Workflow.php
@@ -5,16 +5,24 @@ namespace Picqer\Financials\Moneybird\Entities;
 use Picqer\Financials\Moneybird\Actions\FindAll;
 use Picqer\Financials\Moneybird\Model;
 
+
 /**
- * Class Workflow.
+ * @property string id
+ * @property string type
+ * @property string name
+ * @property string default
+ * @property string currency
+ * @property string language
+ * @property string active
+ * @property string prices_are_incl_tax
+ * @property string created_at
+ * @property string updated_at
  */
 class Workflow extends Model
 {
     use FindAll;
 
-    /**
-     * @var array
-     */
+    
     protected $fillable = [
         'id',
         'type',
@@ -28,8 +36,6 @@ class Workflow extends Model
         'updated_at',
     ];
 
-    /**
-     * @var string
-     */
+    
     protected $endpoint = 'workflows';
 }

--- a/src/Picqer/Financials/Moneybird/Model.php
+++ b/src/Picqer/Financials/Moneybird/Model.php
@@ -105,6 +105,16 @@ abstract class Model
     }
 
     /**
+     * Get the fillable items.
+     *
+     * @return array
+     */
+    public function getFillable()
+    {
+        return $this->fillable;
+    }
+
+    /**
      * Fill the entity from an array.
      *
      * @param  array  $attributes
@@ -151,8 +161,8 @@ abstract class Model
      */
     protected function fillableFromArray(array $attributes)
     {
-        if (count($this->fillable) > 0) {
-            return array_intersect_key($attributes, array_flip($this->fillable));
+        if (count($this->getFillable()) > 0) {
+            return array_intersect_key($attributes, array_flip($this->getFillable()));
         }
 
         return $attributes;
@@ -164,7 +174,7 @@ abstract class Model
      */
     protected function isFillable($key)
     {
-        return in_array($key, $this->fillable, true);
+        return in_array($key, $this->getFillable(), true);
     }
 
     /**
@@ -429,7 +439,7 @@ abstract class Model
     {
         $result = [];
 
-        foreach ($this->fillable as $attribute) {
+        foreach ($this->getFillable() as $attribute) {
             $result[$attribute] = $this->$attribute;
         }
 


### PR DESCRIPTION
# What does this pull request implement?

The `TaxRate` entity can be filtered in Moneybird, as can be seen in the [documentation](https://developer.moneybird.com/api/tax_rates/#get_tax_rates).

This pull request adds the `Filterable` trait to the `TaxRate` entity so that this feature can be used.