### PR TITLE
Make PHP 8.1 compliant

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
@@ -69,6 +69,7 @@ class SendInvoiceOptions implements JsonSerializable
         return $this->scheduled === true;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_filter([

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
@@ -5,6 +5,7 @@ namespace Picqer\Financials\Moneybird\Entities\SalesInvoice;
 use DateTime;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Configuration options when sending an invoice.


### PR DESCRIPTION
The original `jsonSerialize` method signature has changed to `public function jsonSerialize(): mixed;`. This works under PHP 8.1, but to support older PHP versions too, this PR adds the optional `ReturnTypeWillChange` attribute.