### PR TITLE
Add external sales invoice payment registration

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -11,7 +11,9 @@ use Picqer\Financials\Moneybird\Actions\Removable;
 use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Actions\Synchronizable;
 use Picqer\Financials\Moneybird\Connection;
+use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
+
 
 /**
  * Class ExternalSalesInvoice.
@@ -91,5 +93,30 @@ class ExternalSalesInvoice extends Model
         parent::__construct($connection, $attributes);
 
         $this->attachmentPath = 'attachment';
+    }
+
+    /**
+     * Register a payment for the current invoice.
+     *
+     * @param  ExternalSalesInvoicePayment  $salesInvoicePayment  (payment_date and price are required)
+     * @return $this
+     *
+     * @throws ApiException
+     */
+    public function registerPayment(ExternalSalesInvoicePayment $salesInvoicePayment)
+    {
+        if (! isset($salesInvoicePayment->payment_date)) {
+            throw new ApiException('Required [payment_date] is missing');
+        }
+
+        if (! isset($salesInvoicePayment->price)) {
+            throw new ApiException('Required [price] is missing');
+        }
+
+        $this->connection()->post($this->endpoint . '/' . $this->id . '/payments',
+            $salesInvoicePayment->jsonWithNamespace()
+        );
+
+        return $this;
     }
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -14,7 +14,6 @@ use Picqer\Financials\Moneybird\Connection;
 use Picqer\Financials\Moneybird\Exceptions\ApiException;
 use Picqer\Financials\Moneybird\Model;
 
-
 /**
  * Class ExternalSalesInvoice.
  *


### PR DESCRIPTION
Like regular sales invoices, external sales invoices can also be paid. Registering payments for external sales invoices works  the same, except for the endpoint and models used.

This adds the same method "registerPayment" found on the SalesInvoice class, adjusted for the ExternalSalesInvoicePayment.