### PR TITLE
Add downloadable attachment option (as mentioned in the changelog per 2023-07-27)

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -90,6 +90,10 @@ class Estimate extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => EstimateAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'custom_fields' => [
             'entity' => SalesInvoiceCustomField::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/EstimateAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/EstimateAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class EstimateAttachment.
+ */
+class EstimateAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'estimates';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoice.php
@@ -77,6 +77,10 @@ class ExternalSalesInvoice extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => ExternalSalesInvoiceAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'details' => [
             'entity' => ExternalSalesInvoiceDetail::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ExternalSalesInvoiceAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class ExternalSalesInvoiceAttachment.
+ */
+class ExternalSalesInvoiceAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'external_sales_invoices';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
@@ -44,4 +44,14 @@ class GeneralDocument extends Model
      * @var string
      */
     protected $namespace = 'general_document';
+
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => GeneralDocumentAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
 }

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralDocumentAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralDocumentAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class GeneralDocumentAttachment.
+ */
+class GeneralDocumentAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'documents/general_documents';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocument.php
@@ -44,6 +44,10 @@ class GeneralJournalDocument extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => GeneralJournalDocumentAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'general_journal_document_entries' => [
             'entity' => GeneralJournalDocumentEntry::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocumentAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralJournalDocumentAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class GeneralJournalDocumentAttachment.
+ */
+class GeneralJournalDocumentAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'documents/general_journal_documents';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/Generic/Attachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Generic/Attachment.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities\Generic;
+
+use Picqer\Financials\Moneybird\Model;
+
+/**
+ * Class InvoiceDetail.
+ */
+abstract class Attachment extends Model
+{
+    /**
+     * @var string
+     */
+    protected $attachmentPath = 'attachments';
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'administration_id',
+        'attachable_id',
+        'attachable_type',
+        'filename',
+        'content_type',
+        'size',
+        'rotation',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * Download the file.
+     *
+     * @return string file data
+     *
+     * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
+     */
+    public function download()
+    {
+        $response = $this->connection()->download($this->getEndpoint() . '/' . urlencode($this->attachable_id) . '/' . $this->attachmentPath . '/' . urlencode($this->id) . '/download');
+
+        return $response->getBody()->getContents();
+    }
+}

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoice.php
@@ -72,6 +72,10 @@ class PurchaseInvoice extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => PurchaseInvoiceAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'details' => [
             'entity' => PurchaseInvoiceDetail::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoiceAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/PurchaseInvoiceAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class SalesInvoiceAttachment.
+ */
+class PurchaseInvoiceAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'documents/purchase_invoices';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/Receipt.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Receipt.php
@@ -62,6 +62,10 @@ class Receipt extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => ReceiptAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'details' => [
             'entity' => ReceiptDetail::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/ReceiptAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ReceiptAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class ReceiptAttachment.
+ */
+class ReceiptAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'documents/receipts';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice.php
@@ -105,6 +105,10 @@ class SalesInvoice extends Model
      * @var array
      */
     protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => SalesInvoiceAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
         'custom_fields' => [
             'entity' => SalesInvoiceCustomField::class,
             'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoiceAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class SalesInvoiceAttachment.
+ */
+class SalesInvoiceAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'sales_invoices';
+}

--- a/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TypelessDocument.php
@@ -40,4 +40,14 @@ class TypelessDocument extends Model
      * @var string
      */
     protected $namespace = 'typeless_document';
+
+    /**
+     * @var array
+     */
+    protected $multipleNestedEntities = [
+        'attachments' => [
+            'entity' => TypelessDocumentAttachment::class,
+            'type' => self::NESTING_TYPE_ARRAY_OF_OBJECTS,
+        ],
+    ];
 }

--- a/src/Picqer/Financials/Moneybird/Entities/TypelessDocumentAttachment.php
+++ b/src/Picqer/Financials/Moneybird/Entities/TypelessDocumentAttachment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Picqer\Financials\Moneybird\Entities;
+
+use Picqer\Financials\Moneybird\Entities\Generic\Attachment;
+
+/**
+ * Class TypelessDocumentAttachment.
+ */
+class TypelessDocumentAttachment extends Attachment
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'documents/typeless_documents';
+}


### PR DESCRIPTION
Add downloadable attachment option (as mentioned in the changelog per 2023-07-27) for the entities:
- estimates
- external sales invoice
- sales invoice
- document: general document
- document: general journal document
- document: purchase invoice
- document: receipt
- document: typeless document

For example, get info and content from an attachment added to a SalesInvoice:
```php
// Create the Moneybird client
$connection = connect($redirectUrl, $clientId, $clientSecret);
$connection->setAdministrationId($administrationId);
$moneybird = new \Picqer\Financials\Moneybird\Moneybird($connection);

// Get the sales invoices from our administration
$salesInvoice = $moneybird->salesInvoice()->find(394429746230855571);

foreach ($salesInvoice->attachments as $salesInvoiceAttachment) {
    var_dump($salesInvoiceAttachment); // dumps the API response object
    var_dump($salesInvoiceAttachment->download()); // returns the string of the file
}
```

In the background, when you call the download endpoint, you'll be redirected to a temporary URL that contains the file content.

From the API docs:
> Download the attachment. The response will be a redirect to a temporarily available URL where the attachment can be downloaded. Use the `Location` header in the response to download the attachment.