### PR TITLE
Support changing estimate state

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -151,8 +151,9 @@ class Estimate extends Model
 
     /**
      * Change the state of the estimate.
+     *
      * @see https://developer.moneybird.com/api/estimates/#patch_estimates_id_change_state
-     * 
+     *
      * @param  string  $state
      * @return $this
      *

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -150,27 +150,29 @@ class Estimate extends Model
     }
 
     /**
-     * Change the state of the estimate
+     * Change the state of the estimate.
      * @see https://developer.moneybird.com/api/estimates/#patch_estimates_id_change_state
-     * @param string $state
+     * 
+     * @param  string  $state
      * @return $this
      *
      * @throws ApiException
      */
-    public function changeState(string $state) {
-        if (!in_array($state, [
-            'accepted', 
-            'rejected', 
-            'open', 
-            'late', 
-            'billed', 
+    public function changeState(string $state)
+    {
+        if (! in_array($state, [
+            'accepted',
+            'rejected',
+            'open',
+            'late',
+            'billed',
             'archived',
         ], true)) {
             throw new InvalidArgumentException("Expected valid state. Received: '$state'");
         }
 
         $response = $this->connection()->patch($this->getEndpoint() . '/' . urlencode($this->id) . '/change_state', json_encode([
-            'state' => $state
+            'state' => $state,
         ]));
 
         if (is_array($response)) {

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -161,17 +161,6 @@ class Estimate extends Model
      */
     public function changeState(string $state)
     {
-        if (! in_array($state, [
-            'accepted',
-            'rejected',
-            'open',
-            'late',
-            'billed',
-            'archived',
-        ], true)) {
-            throw new InvalidArgumentException("Expected valid state. Received: '$state'");
-        }
-
         $response = $this->connection()->patch($this->getEndpoint() . '/' . urlencode($this->id) . '/change_state', json_encode([
             'state' => $state,
         ]));

--- a/src/Picqer/Financials/Moneybird/Entities/Estimate.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Estimate.php
@@ -148,4 +148,35 @@ class Estimate extends Model
 
         return $this;
     }
+
+    /**
+     * Change the state of the estimate
+     * @see https://developer.moneybird.com/api/estimates/#patch_estimates_id_change_state
+     * @param string $state
+     * @return $this
+     *
+     * @throws ApiException
+     */
+    public function changeState(string $state) {
+        if (!in_array($state, [
+            'accepted', 
+            'rejected', 
+            'open', 
+            'late', 
+            'billed', 
+            'archived',
+        ], true)) {
+            throw new InvalidArgumentException("Expected valid state. Received: '$state'");
+        }
+
+        $response = $this->connection()->patch($this->getEndpoint() . '/' . urlencode($this->id) . '/change_state', json_encode([
+            'state' => $state
+        ]));
+
+        if (is_array($response)) {
+            $this->selfFromResponse($response);
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
When updating an estimate, changing it's state is not allowed and silently ignored. Changing the state of an estimate requires a separate API call. The method added exposes this endpoint through the PHP Client.