### PR TITLE
Allow contact people to be managed

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Contact.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Contact.php
@@ -123,4 +123,12 @@ class Contact extends Model
             $this->getEndpoint() . '/' . $this->id . '/moneybird_payments_mandate'
         );
     }
+
+    public function addContactPerson(array $attributes): ContactPeople
+    {
+        $attributes['contact_id'] = $this->id;
+        $contactPerson = new ContactPeople($this->connection(), $attributes);
+
+        return $contactPerson->save();
+    }
 }

--- a/src/Picqer/Financials/Moneybird/Entities/ContactPeople.php
+++ b/src/Picqer/Financials/Moneybird/Entities/ContactPeople.php
@@ -2,12 +2,16 @@
 
 namespace Picqer\Financials\Moneybird\Entities;
 
+use Picqer\Financials\Moneybird\Actions\FindOne;
+use Picqer\Financials\Moneybird\Actions\Removable;
+use Picqer\Financials\Moneybird\Actions\Storable;
 use Picqer\Financials\Moneybird\Model;
 
 /**
  * Class ContactPeople.
  *
  * @property string $id
+ * @property string $contact_id
  * @property string $administration_id
  * @property string $firstname
  * @property string lastname
@@ -20,11 +24,14 @@ use Picqer\Financials\Moneybird\Model;
  */
 class ContactPeople extends Model
 {
+    use FindOne, Storable, Removable;
+
     /**
      * @var array
      */
     protected $fillable = [
         'id',
+        'contact_id',
         'administration_id',
         'firstname',
         'lastname',
@@ -35,4 +42,14 @@ class ContactPeople extends Model
         'updated_at',
         'version',
     ];
+
+    protected $namespace = 'contact_person';
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return 'contacts/' . $this->contact_id . '/contact_people';
+    }
 }

--- a/src/Picqer/Financials/Moneybird/Moneybird.php
+++ b/src/Picqer/Financials/Moneybird/Moneybird.php
@@ -5,6 +5,7 @@ namespace Picqer\Financials\Moneybird;
 use Picqer\Financials\Moneybird\Entities\Administration;
 use Picqer\Financials\Moneybird\Entities\Contact;
 use Picqer\Financials\Moneybird\Entities\ContactCustomField;
+use Picqer\Financials\Moneybird\Entities\ContactPeople;
 use Picqer\Financials\Moneybird\Entities\CustomField;
 use Picqer\Financials\Moneybird\Entities\DocumentStyle;
 use Picqer\Financials\Moneybird\Entities\Estimate;
@@ -85,6 +86,15 @@ class Moneybird
     public function contact($attributes = [])
     {
         return new Contact($this->connection, $attributes);
+    }
+
+    /**
+     * @param  array  $attributes
+     * @return \Picqer\Financials\Moneybird\Entities\ContactPeople
+     */
+    public function contactPerson($attributes = [])
+    {
+        return new ContactPeople($this->connection, $attributes);
     }
 
     /**

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Picqer\Financials\Moneybird\Entities\Administration;
 use Picqer\Financials\Moneybird\Entities\Contact;
 use Picqer\Financials\Moneybird\Entities\ContactCustomField;
+use Picqer\Financials\Moneybird\Entities\ContactPeople;
 use Picqer\Financials\Moneybird\Entities\CustomField;
 use Picqer\Financials\Moneybird\Entities\DocumentStyle;
 use Picqer\Financials\Moneybird\Entities\Estimate;
@@ -61,6 +62,11 @@ class EntityTest extends TestCase
     public function testContactEntity()
     {
         $this->performEntityTest(Contact::class);
+    }
+
+    public function testContactPeopleEntity()
+    {
+        $this->performEntityTest(ContactPeople::class);
     }
 
     public function testContactCustomFieldEntity()


### PR DESCRIPTION
Allow creating, updating and removing contact people.

We might want to consider renaming `ContactPeople` to `ContactPerson` in a future major release since it's the only entity where the name is pluralized.