### PR TITLE
Add version to fillable where missing

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
@@ -72,6 +72,7 @@ class FinancialMutation extends Model
         'payments',
         'ledger_account_bookings',
         'account_servicer_transaction_id',
+        'version',
     ];
 
     /**

--- a/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
+++ b/src/Picqer/Financials/Moneybird/Entities/GeneralDocument.php
@@ -33,6 +33,7 @@ class GeneralDocument extends Model
         'updated_at',
         'notes',
         'attachments',
+        'version',
     ];
 
     /**


### PR DESCRIPTION
Hello, 

I have found several models that are 'Synchronizable', to be missing the version field in the fillable array, leading to the inability to keep track of versions for those models. In this merge request, I suggest adding the respective field to the GeneralDocument and FinancialMutation models.

If this was a deliberate choice, please also kindly let me know :-) 