### PR TITLE
Allow paged filter

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -11,13 +11,13 @@ trait Filterable
 
     /**
      * @param  array  $filters
-     * @param  int|null $perPage Number of results per page
-     * @param  int|null $page Page to load, typically starts at 1
+     * @param  int|null  $perPage Number of results per page
+     * @param  int|null  $page Page to load, typically starts at 1
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    public function filter(array $filters, ?int $perPage = null, ?int $page = null)
+    public function filter(array $filters, $perPage = null, $page = null)
     {
         $filterList = [];
         foreach ($filters as $key => $value) {
@@ -27,7 +27,7 @@ trait Filterable
         $result = $this->connection()->get($this->getFilterEndpoint(), [
             'filter' => implode(',', $filterList),
             'per_page' => $perPage,
-            'page' => $page,                             
+            'page' => $page,
         ], false);
 
         return $this->collectionFromResult($result);

--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -11,18 +11,24 @@ trait Filterable
 
     /**
      * @param  array  $filters
+     * @param  int|null $perPage Number of results per page
+     * @param  int|null $page Page to load, typically starts at 1
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    public function filter(array $filters)
+    public function filter(array $filters, ?int $perPage = null, ?int $page = null)
     {
         $filterList = [];
         foreach ($filters as $key => $value) {
             $filterList[] = $key . ':' . $value;
         }
 
-        $result = $this->connection()->get($this->getFilterEndpoint(), ['filter' => implode(',', $filterList)]);
+        $result = $this->connection()->get($this->getFilterEndpoint(), [
+            'filter' => implode(',', $filterList),
+            'per_page' => $perPage,
+            'page' => $page,                             
+        ], false);
 
         return $this->collectionFromResult($result);
     }

--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -11,8 +11,8 @@ trait Filterable
 
     /**
      * @param  array  $filters
-     * @param  int|null  $perPage Number of results per page
-     * @param  int|null  $page Page to load, typically starts at 1
+     * @param  int|null  $perPage  Number of results per page
+     * @param  int|null  $page  Page to load, typically starts at 1
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException


### PR DESCRIPTION
When using the `Filterable` trait, one can choose to use `filter()` to get a first batch/page of results or `filterAll()` to get al results. 

In some cases it is useful to be able to influence which page of the results to load. 

For example when filtering the SalesInvoices of a Contact and checking them for a specific CustomField (for example a UUID): when _a lot_ of SalesInvoices exist for the Contact, you want to prevent using filterAll() which loads all SalesInvoices at once which might exhaust the available memory, and go over the results in small batches. To do so, the pagination parameters `per_page` and `page` are needed. 