### PR TITLE
Deprecation of events in the Webhook API

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/Webhook.php
+++ b/src/Picqer/Financials/Moneybird/Entities/Webhook.php
@@ -22,7 +22,7 @@ class Webhook extends Model
     protected $fillable = [
         'id',
         'url',
-        'events',
+        'enabled_events',
         'last_http_status',
         'last_http_body',
         'token',


### PR DESCRIPTION
1. [Deprecation of events in the Webhook API](https://developer.moneybird.com/changelog/):
  * The events attribute on webhook entities is considered deprecated and is replaced by enabled_events, starting January 1st 2025 events will be removed and will no longer be accepted.
  * POST requests` :administration_id/webhooks` now accept enabled_events instead of events.
  *  GET requests `:administration_id/webhooks/:id` now return both events and enabled_events, until January 1st 2025.