### PR TITLE
Allow fetchAll for filter

### DIFF
--- a/src/Picqer/Financials/Moneybird/Actions/Filterable.php
+++ b/src/Picqer/Financials/Moneybird/Actions/Filterable.php
@@ -12,23 +12,29 @@ trait Filterable
     /**
      * @param  array  $filters
      * @param  int|null  $perPage  Number of results per page
-     * @param  int|null  $page  Page to load, typically starts at 1
+     * @param  int|null  $page  Page to load, typically starts at 1.
+     * @param  bool  $fetchAll  Whether to fetch all results or just the current page, this will override perPage and page parameters.
      * @return mixed
      *
      * @throws \Picqer\Financials\Moneybird\Exceptions\ApiException
      */
-    public function filter(array $filters, $perPage = null, $page = null)
+    public function filter(array $filters, $perPage = null, $page = null, $fetchAll = false)
     {
         $filterList = [];
         foreach ($filters as $key => $value) {
             $filterList[] = $key . ':' . $value;
         }
 
+        if($fetchAll === true) {
+            $perPage = null; // If fetching all, perPage should not be set
+            $page = null; // If fetching all, page should not be set
+        }
+
         $result = $this->connection()->get($this->getFilterEndpoint(), [
             'filter' => implode(',', $filterList),
             'per_page' => $perPage,
             'page' => $page,
-        ], false);
+        ], $fetchAll);
 
         return $this->collectionFromResult($result);
     }


### PR DESCRIPTION
Allow to use $fetchAll to get all records for a filter.