### PR TITLE
Add support for default delivery method and Peppol

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
@@ -16,6 +16,7 @@ class SendInvoiceOptions implements JsonSerializable
     const METHOD_SIMPLER_INVOICING = 'Simplerinvoicing';
     const METHOD_POST = 'Post';
     const METHOD_MANUAL = 'Manual';
+    const METHOD_DEFAULT = null;
 
     /** @var string */
     private $method;
@@ -56,6 +57,7 @@ class SendInvoiceOptions implements JsonSerializable
             self::METHOD_SIMPLER_INVOICING,
             self::METHOD_POST,
             self::METHOD_MANUAL,
+            self::METHOD_DEFAULT,
         ];
     }
 
@@ -73,7 +75,7 @@ class SendInvoiceOptions implements JsonSerializable
     #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return array_filter([
+        $result = array_filter([
             'delivery_method' => $this->getMethod(),
             'sending_scheduled' => $this->isScheduled() ?: null,
             'deliver_ubl' => $this->getDeliverUbl(),
@@ -84,6 +86,11 @@ class SendInvoiceOptions implements JsonSerializable
         ], function ($item) {
             return $item !== null;
         });
+        if (!$result) {
+            // Make sure the result is an object, not an array
+            $result = new \StdClass();
+        }
+        return $result;
     }
 
     /**
@@ -95,7 +102,7 @@ class SendInvoiceOptions implements JsonSerializable
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getMethod()
     {
@@ -103,7 +110,7 @@ class SendInvoiceOptions implements JsonSerializable
     }
 
     /**
-     * @param  string  $method
+     * @param  string|null  $method
      */
     public function setMethod($method)
     {

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
@@ -16,6 +16,7 @@ class SendInvoiceOptions implements JsonSerializable
     const METHOD_SIMPLER_INVOICING = 'Simplerinvoicing';
     const METHOD_POST = 'Post';
     const METHOD_MANUAL = 'Manual';
+    const METHOD_PEPPOL = 'Peppol';
     const METHOD_DEFAULT = null;
 
     /** @var string */

--- a/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
+++ b/src/Picqer/Financials/Moneybird/Entities/SalesInvoice/SendInvoiceOptions.php
@@ -87,10 +87,12 @@ class SendInvoiceOptions implements JsonSerializable
         ], function ($item) {
             return $item !== null;
         });
-        if (!$result) {
+
+        if (! $result) {
             // Make sure the result is an object, not an array
-            $result = new \StdClass();
+            $result = new \stdClass();
         }
+
         return $result;
     }
 


### PR DESCRIPTION
See #316 

Previously, it was not possible to use Moneybird's 'default' delivery method (where Moneybird determines the method based on contact and workflow settings). I have updated the `SendInvoiceOptions` class to support `null` as a method value. When set to `null`, the method key is omitted from the JSON-encoded options, triggering Moneybird's default behavior.

To maintain backward compatibility, I have not changed the default values in the constructor or method arguments. Consequently, to use the default delivery method, you must explicitly set it to null as shown below:
```php
$sendInvoiceOptions = new SendInvoiceOptions();
// Let Moneybird decide
$sendInvoiceOptions->setMethod(null);
$invoice->sendInvoice($sendInvoiceOptions);
```

As a bonus, I added the Peppol method to the `SendInvoiceOptions` class.